### PR TITLE
Added formatting for when multiple certs are in a single file.

### DIFF
--- a/display.go
+++ b/display.go
@@ -47,6 +47,7 @@ Subject Key ID  : {{.SubjectKeyId | hexify}}
 Authority Key ID: {{.AuthorityKeyId | hexify}}
 Alternate DNS Names: {{.DNSNames}}
 Serial Number: {{.SerialNumber}}
+
 `
 
 // displayCert takes in an x509 Certificate object and prints out relevant

--- a/main.go
+++ b/main.go
@@ -45,7 +45,8 @@ func main() {
 			fmt.Fprintf(os.Stderr, "%s\n", err)
 			os.Exit(1)
 		}
-		for _, cert := range certs {
+		for i, cert := range certs {
+			fmt.Println("CERTIFICATE", i+1)
 			displayCert(cert)
 		}
 	}


### PR DESCRIPTION
Each cert is now newline separated and they are numbered off.

@csstaub PTAL
