### PR TITLE
Use glide for vendoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+vendor/
+certigo

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,11 +6,11 @@ go:
   - 1.6
 
 before_install:
-  - go get -v ./...
+  - go get github.com/Masterminds/glide
+  - make depends
 
 install:
-  - go build -v .
+  - make build
 
 before_script:
-  - go vet -v .               # run go vet to find suspicious constructs
-  - "! (gofmt -d . | grep .)" # ensure that all code is properly formatted
+  - make check

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,12 @@
+# Find all non-vendor source files
+SOURCE_FILES = $(shell find . \( -name '*.go' -not -path './vendor*' \)) 
+
+depends:
+	glide -q install
+
+build:
+	go build .
+
+check:
+	go vet -v .
+	!(gofmt -d $(SOURCE_FILES) | grep .)

--- a/README.md
+++ b/README.md
@@ -4,4 +4,15 @@
 [![build](https://travis-ci.org/square/certigo.svg?branch=master)](https://travis-ci.org/square/certigo)
 [![report](https://goreportcard.com/badge/github.com/square/certigo)](https://goreportcard.com/report/github.com/square/certigo)
 
-certigo is a utility to examine and validate certificates in a variety of formats.
+Certigo is a utility to examine and validate certificates in a variety of formats.
+
+### Build
+
+We use [glide](https://glide.sh) for vendoring.
+Use `go get github.com/Masterminds/glide` or `brew install glide` (on OS X) to install it.
+
+Then, to pull in dependencies and build certigo:
+
+    make depends build
+
+Certigo is tested with Go 1.6.

--- a/glide.lock
+++ b/glide.lock
@@ -1,0 +1,29 @@
+hash: 21621818785615e3d0798f3dec9edbf60da7f4e5c19c86af52c8bcc6f2f3891c
+updated: 2016-06-02T14:23:24.530708211-07:00
+imports:
+- name: github.com/alecthomas/template
+  version: a0175ee3bccc567396460bf5acd36800cb10c49c
+  subpackages:
+  - parse
+- name: github.com/alecthomas/units
+  version: 2efee857e7cfd4f3d0138cc3cbb1b4966962b93a
+- name: github.com/fatih/color
+  version: 533cd7fd8a85905f67a1753afb4deddc85ea174f
+- name: github.com/mattn/go-colorable
+  version: 9cbef7c35391cca05f15f8181dc0b18bc9736dbb
+  repo: https://github.com/mattn/go-colorable
+- name: github.com/mattn/go-isatty
+  version: 56b76bdf51f7708750eac80fa38b952bb9f32639
+  repo: https://github.com/mattn/go-isatty
+- name: golang.org/x/crypto
+  version: 5bcd134fee4dd1475da17714aac19c0aa0142e2f
+  subpackages:
+  - pkcs12
+  - pkcs12/internal/rc2
+- name: golang.org/x/sys
+  version: 076b546753157f758b316e59bcb51e6807c04057
+  subpackages:
+  - unix
+- name: gopkg.in/alecthomas/kingpin.v2
+  version: 8cccfa8eb2e3183254457fb1749b2667fbc364c7
+devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,0 +1,7 @@
+package: github.com/square/certigo
+import:
+- package: github.com/fatih/color
+- package: golang.org/x/crypto
+  subpackages:
+  - pkcs12
+- package: gopkg.in/alecthomas/kingpin.v2


### PR DESCRIPTION
r: @christodenny @alokmenghrajani @mcpherrinm @worldwise001 
Setup glide for vendoring/pinning dependencies to specific versions. Also add makefile. Fixes #27.