### PR TITLE
Added support to output alias info for jceks certs.

### DIFF
--- a/display.go
+++ b/display.go
@@ -20,6 +20,7 @@ import (
 	"bytes"
 	"crypto/x509"
 	"encoding/hex"
+	"fmt"
 	"os"
 	"strings"
 	"text/template"
@@ -54,10 +55,11 @@ Email Addresses: {{range .EmailAddresses}}
 Serial Number: {{.SerialNumber}} {{end}}
 `
 
-// displayCert takes in an x509 Certificate object and prints out relevant
+// displayCert takes in an x509 Certificate object and an alias
+// (for jckes certs, blank otherwise), and prints out relevant
 // information. Start and end dates are colored based on whether or not
 // the certificate is expired, not expired, or close to expiring.
-func displayCert(cert *x509.Certificate) {
+func displayCert(cert *x509.Certificate, alias string) {
 	funcMap := template.FuncMap{
 		"hexify":    hexify,
 		"certStart": certStart,
@@ -65,6 +67,9 @@ func displayCert(cert *x509.Certificate) {
 	}
 	t := template.New("Cert template").Funcs(funcMap)
 	t, _ = t.Parse(layout)
+	if alias != "" {
+		fmt.Println("Alias:", alias)
+	}
 	t.Execute(os.Stdout, cert)
 
 }

--- a/display.go
+++ b/display.go
@@ -58,7 +58,7 @@ Serial Number: {{.SerialNumber}} {{end}}
 // (for jckes certs, blank otherwise), and prints out relevant
 // information. Start and end dates are colored based on whether or not
 // the certificate is expired, not expired, or close to expiring.
-func displayCert(cert CertWithAlias) {
+func displayCert(cert certWithAlias) {
 	funcMap := template.FuncMap{
 		"hexify":    hexify,
 		"certStart": certStart,

--- a/display.go
+++ b/display.go
@@ -18,7 +18,6 @@ package main
 
 import (
 	"bytes"
-	"crypto/x509"
 	"encoding/hex"
 	"fmt"
 	"os"
@@ -59,7 +58,7 @@ Serial Number: {{.SerialNumber}} {{end}}
 // (for jckes certs, blank otherwise), and prints out relevant
 // information. Start and end dates are colored based on whether or not
 // the certificate is expired, not expired, or close to expiring.
-func displayCert(cert *x509.Certificate, alias string) {
+func displayCert(cert CertWithAlias) {
 	funcMap := template.FuncMap{
 		"hexify":    hexify,
 		"certStart": certStart,
@@ -67,10 +66,10 @@ func displayCert(cert *x509.Certificate, alias string) {
 	}
 	t := template.New("Cert template").Funcs(funcMap)
 	t, _ = t.Parse(layout)
-	if alias != "" {
-		fmt.Println("Alias:", alias)
+	if cert.alias != "" {
+		fmt.Println("Alias:", cert.alias)
 	}
-	t.Execute(os.Stdout, cert)
+	t.Execute(os.Stdout, cert.cert)
 
 }
 

--- a/main.go
+++ b/main.go
@@ -47,7 +47,7 @@ var fileExtToFormat = map[string]string{
 	".jceks": "JCEKS",
 }
 
-type CertWithAlias struct {
+type certWithAlias struct {
 	alias string
 	cert  *x509.Certificate
 }
@@ -91,8 +91,8 @@ func formatForFile(filename, format string) (string, bool) {
 // is specified for the file, getCerts guesses what format was used
 // based on the file extension used in the file name. If it can't
 // guess based on this it returns and error.
-func getCerts(file, format string) ([]CertWithAlias, error) {
-	var certs []CertWithAlias
+func getCerts(file, format string) ([]certWithAlias, error) {
+	var certs []certWithAlias
 	data, _ := ioutil.ReadFile(file)
 	switch format {
 	case "PEM":
@@ -102,7 +102,7 @@ func getCerts(file, format string) ([]CertWithAlias, error) {
 			if err != nil {
 				return nil, err
 			}
-			certs = append(certs, CertWithAlias{cert: cert})
+			certs = append(certs, certWithAlias{cert: cert})
 			block, data = pem.Decode(data)
 		}
 	case "PKCS12":
@@ -119,7 +119,7 @@ func getCerts(file, format string) ([]CertWithAlias, error) {
 				if err != nil {
 					return nil, err
 				}
-				certs = append(certs, CertWithAlias{cert: cert})
+				certs = append(certs, certWithAlias{cert: cert})
 			}
 		}
 	case "JCEKS":
@@ -135,7 +135,7 @@ func getCerts(file, format string) ([]CertWithAlias, error) {
 			if err != nil {
 				return nil, err
 			}
-			certs = append(certs, CertWithAlias{cert: cert, alias: alias})
+			certs = append(certs, certWithAlias{cert: cert, alias: alias})
 		}
 		for _, alias := range keyStore.ListPrivateKeys() {
 			fmt.Printf("Enter password for alias [%s]: ", alias)
@@ -145,7 +145,7 @@ func getCerts(file, format string) ([]CertWithAlias, error) {
 				return nil, err
 			}
 			for _, cert := range certArr {
-				certs = append(certs, CertWithAlias{cert: cert, alias: alias})
+				certs = append(certs, certWithAlias{cert: cert, alias: alias})
 			}
 		}
 	default:


### PR DESCRIPTION
GetCerts now returns an array of alias strings along with certs,
the array contains empty strings if not jceks. DisplayCerts
now takes in an alias string along with the cert and only prints
it if non empty.

@csstaub ptal