### PR TITLE
Put serial on top of output

### DIFF
--- a/display.go
+++ b/display.go
@@ -28,7 +28,8 @@ import (
 	"github.com/fatih/color"
 )
 
-var layout = `Not Before: {{.NotBefore | certStart}}
+var layout = `Serial: {{.SerialNumber}}
+Not Before: {{.NotBefore | certStart}}
 Not After : {{.NotAfter | certEnd}}
 Signature algorithm: {{.SignatureAlgorithm}}
 Subject Info: {{if .Subject.CommonName}}
@@ -50,8 +51,7 @@ Alternate DNS Names: {{range .DNSNames}}
 Alternate IP Addresses: {{range .IPAddresses}}	
 	{{.}} {{end}} {{end}} {{if .EmailAddresses}}
 Email Addresses: {{range .EmailAddresses}}
-	{{.}} {{end}} {{end}} {{if .SerialNumber}}
-Serial Number: {{.SerialNumber}} {{end}}
+	{{.}} {{end}} {{end}}
 `
 
 // displayCert takes in an x509 Certificate object and an alias


### PR DESCRIPTION
r: @christodenny 
Put serial at the top of the output, because that's what most other tools do. Also removes the conditional around the serial number, since it will always be present.