### PR TITLE
Slightly better spacing in SVG files

### DIFF
--- a/output_1.svg
+++ b/output_1.svg
@@ -2,7 +2,7 @@
 <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="100%" height="42em">
+     width="100%" height="42.5em">
      <rect x="0" y="0" width="100%" height="100%" fill="#f7f7f7" stroke-width="2" />
      <text font-family="monospace" y="10">
        <tspan  x="10" dy="1.2em">&#36; cat certs/cert.pem | ./certigo dump</tspan>

--- a/output_2.svg
+++ b/output_2.svg
@@ -2,7 +2,7 @@
 <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="100%" height="45em">
+     width="100%" height="45.5em">
      <rect x="0" y="0" width="100%" height="100%" fill="#f7f7f7" stroke-width="2" />
      <text font-family="monospace" y="10">
        <tspan  x="10" dy="1.2em">&#36; ./certigo dump certs/cert.jks</tspan>

--- a/output_3.svg
+++ b/output_3.svg
@@ -2,7 +2,7 @@
 <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
-     width="100%" height="87em">
+     width="100%" height="86.5em">
      <rect x="0" y="0" width="100%" height="100%" fill="#f7f7f7" stroke-width="2" />
      <text font-family="monospace" y="10">
        <tspan  x="10" dy="1.2em">&#36; openssl s_client -connect squareup.com:443 -showcerts &#60; /dev/null | ./certigo dump</tspan>


### PR DESCRIPTION
@alokmenghrajani @mcpherrinm @christodenny 
Slightly better/more consistent spacing at the end of SVG examples. Third example had a bit too much margin at the bottom, first two examples had no margin at the bottom. 