### PR TITLE
Support multiple file arguments

### DIFF
--- a/display.go
+++ b/display.go
@@ -84,7 +84,7 @@ func displayCert(cert certWithAlias) {
 	t := template.New("Cert template").Funcs(funcMap)
 	t, _ = t.Parse(layout)
 	if cert.alias != "" {
-		fmt.Println("Alias:", cert.alias)
+		fmt.Println("Alias :", cert.alias)
 	}
 	t.Execute(os.Stdout, cert.cert)
 


### PR DESCRIPTION
r: @christodenny @alokmenghrajani @mcpherrinm

Support multiple file arguments, making it possible to run e.g. `certigo dump test-certs/*.crt`.