### PR TITLE
Display PKCS12 friendly name for certs

### DIFF
--- a/main.go
+++ b/main.go
@@ -217,7 +217,7 @@ func getCerts(reader io.Reader, filename string, format string) ([]certWithAlias
 				if err != nil {
 					return nil, err
 				}
-				certs = append(certs, certWithAlias{file: filename, cert: cert})
+				certs = append(certs, certWithAlias{alias: block.Headers["friendlyName"], file: filename, cert: cert})
 			}
 		}
 	case "JCEKS":


### PR DESCRIPTION
r: @christodenny @alokmenghrajani @mcpherrinm
Display PKCS12 friendly name for certs. The `crypto/pkcs12` package puts safe bag attrs in the PEM header, so we can read it from there.