### PR TITLE
Print newline after cert dump from connect

### DIFF
--- a/main.go
+++ b/main.go
@@ -107,6 +107,7 @@ func main() {
 		for i, cert := range conn.ConnectionState().PeerCertificates {
 			fmt.Printf("** CERTIFICATE %d **\n", i+1)
 			displayCert(certWithAlias{cert: cert})
+			fmt.Println()
 		}
 	}
 }


### PR DESCRIPTION
r: @mcpherrinm 
Dumping from file prints newlines in between certs for readability, this changes the connect command to do the same. 