### PR TITLE
Support PKCS7 envelopes, multiple certificates in DER streams

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ We use [glide][1] for managing vendored dependencies.
 
 Certigo can read certificates/keystores in various formats and dump them to stdout.
 
-Currently supported formats are DER, PEM, JCEKS/JKS, PKCS7 and PKCS12. Certigo will display information in a human-readable way, and print warnings for common mistakes (such as small key sizes or weak signatures/hash functions). Certigo can also convert any input to a series of PEM blocks, which is useful if you want to e.g. dump the contents of PKCS12/JCEKS keystores into something more useful.
+Currently supported formats are X.509 (DER/PEM), JCEKS/JKS, PKCS7 and PKCS12. Certigo will display information in a human-readable way, and print warnings for common mistakes (such as small key sizes or weak signatures/hash functions). Certigo can also convert any input to a series of PEM blocks, which is useful if you want to e.g. dump the contents of PKCS12/JCEKS keystores into something more useful.
 
 ```
 usage: certigo [<flags>] <command> [<args> ...]

--- a/pkcs7/pkcs7.go
+++ b/pkcs7/pkcs7.go
@@ -24,13 +24,17 @@ import (
 
 var signedDataIdentifier = asn1.ObjectIdentifier([]int{1, 2, 840, 113549, 1, 7, 2})
 
-type signedDataEnvelope struct {
+// SignedDataEnvelope represents a wrapped SignedData
+// object found in PEM-encoded PKCS7 blocks.
+type SignedDataEnvelope struct {
+	Raw        asn1.RawContent
 	Type       asn1.ObjectIdentifier
-	SignedData signedData `asn1:"tag:0,explicit,optional"`
+	SignedData SignedData `asn1:"tag:0,explicit,optional"`
 }
 
+// SignedData contains signed data and related info.
 // Refer to RFC 2315, Section 9.1 for definition of this type.
-type signedData struct {
+type SignedData struct {
 	Version          int
 	DigestAlgorithms []asn1.ObjectIdentifier `asn1:"set"`
 	ContentInfo      asn1.RawValue
@@ -39,28 +43,57 @@ type signedData struct {
 	SignerInfos      []asn1.RawValue `asn1:"set"`
 }
 
+// ParseSignedData parses one (or more) signed data blocks from a byte array.
+func ParseSignedData(data []byte) ([]*SignedDataEnvelope, error) {
+	var err error
+	var block *SignedDataEnvelope
+	var out []*SignedDataEnvelope
+
+	for rest := data; len(rest) > 0; {
+		block, rest, err = parseSignedData(rest)
+		if err != nil {
+			break
+		}
+		out = append(out, block)
+	}
+
+	return out, err
+}
+
+func parseSignedData(data []byte) (*SignedDataEnvelope, []byte, error) {
+	var envelope SignedDataEnvelope
+	rest, err := asn1.Unmarshal(data, &envelope)
+	if err != nil {
+		return nil, data, err
+	}
+
+	if !signedDataIdentifier.Equal(envelope.Type) {
+		return nil, data, fmt.Errorf("unexpected object identifier (was %s, expecting %s)", envelope.Type.String(), signedDataIdentifier.String())
+	}
+
+	if envelope.SignedData.Version != 1 {
+		return nil, data, fmt.Errorf("unknown version number in signed data block (was %d, expecting 1)", envelope.SignedData.Version)
+	}
+
+	return &envelope, rest, nil
+}
+
 // ExtractCertificates reads a SignedData type and returns the embedded
 // certificates (if present in the structure).
 func ExtractCertificates(data []byte) ([]*x509.Certificate, error) {
-	var envelope signedDataEnvelope
-	_, err := asn1.Unmarshal(data, &envelope)
+	blocks, err := ParseSignedData(data)
 	if err != nil {
 		return nil, err
 	}
 
-	if !signedDataIdentifier.Equal(envelope.Type) {
-		return nil, fmt.Errorf("unexpected object identifier (was %s, expecting %s)", envelope.Type.String(), signedDataIdentifier.String())
-	}
-
-	if envelope.SignedData.Version != 1 {
-		return nil, fmt.Errorf("unknown version number in signed data block (was %d, expecting 1)", envelope.SignedData.Version)
-	}
-
-	certs := make([]*x509.Certificate, len(envelope.SignedData.Certificates))
-	for i, raw := range envelope.SignedData.Certificates {
-		certs[i], err = x509.ParseCertificate(raw.FullBytes)
-		if err != nil {
-			return nil, err
+	certs := []*x509.Certificate{}
+	for _, block := range blocks {
+		for _, raw := range block.SignedData.Certificates {
+			cert, err := x509.ParseCertificate(raw.FullBytes)
+			if err != nil {
+				return nil, err
+			}
+			certs = append(certs, cert)
 		}
 	}
 


### PR DESCRIPTION
r: @worldwise001 @mcpherrinm @stfinney @christodenny 

Changes:
* Support PKCS7 envelopes in DER streams (previously only worked via PEM input)
* Support multiple certificates in DER streams (instead of just one)