### PR TITLE
Strip headers from PEM output blocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,12 +54,12 @@ Commands:
 
 Display information about a certificate (from a file, or from stdin):
 
-<img src="https://cdn.rawgit.com/square/certigo/142ea7a63126d1366194cf0eb746abbac2eb3f09/examples/example_1.svg" width="100%" height="100%">
+<img src="https://cdn.rawgit.com/square/certigo/0a355c64b7200e9fda65b68f6fb81730b3b7d341/examples/example_1.svg" width="100%" height="100%">
 
 Export certificates/keys from a keystore into PEM blocks:
 
-<img src="https://cdn.rawgit.com/square/certigo/142ea7a63126d1366194cf0eb746abbac2eb3f09/examples/example_2.svg" width="100%" height="100%">
+<img src="https://cdn.rawgit.com/square/certigo/0a355c64b7200e9fda65b68f6fb81730b3b7d341/examples/example_2.svg" width="100%" height="100%">
 
 Display information about a certificate from a remote server:
 
-<img src="https://cdn.rawgit.com/square/certigo/142ea7a63126d1366194cf0eb746abbac2eb3f09/examples/example_3.svg" width="100%" height="100%">
+<img src="https://cdn.rawgit.com/square/certigo/0a355c64b7200e9fda65b68f6fb81730b3b7d341/examples/example_3.svg" width="100%" height="100%">

--- a/examples/example_2.svg
+++ b/examples/example_2.svg
@@ -3,16 +3,12 @@
 <svg version="1.1"
      xmlns="http://www.w3.org/2000/svg"
      xmlns:xlink="http://www.w3.org/1999/xlink"
-     viewBox="0 0 60 40.6">
+     viewBox="0 0 60 31">
      <rect x="0" y="0" width="100%" height="100%" fill="#f7f7f7" stroke-width="2"/>
      <text font-family="monospace" font-size="1">
        <tspan x="0.5" dy="1.2">&#36; certigo dump --pem keystore.p12</tspan>
        <tspan x="0.5" dy="1.2">Enter password:</tspan>
        <tspan x="0.5" dy="1.2">-----BEGIN CERTIFICATE-----</tspan>
-       <tspan x="0.5" dy="1.2">friendlyName: example-elliptic-sha1</tspan>
-       <tspan x="0.5" dy="1.2">localKeyId: dd50ce5c559b63733fbd0f6f95ce4d7527777698</tspan>
-       <tspan x="0.5" dy="1.2">originFile: keystore.p12</tspan>
-       <tspan x="0.5" dy="1.2">&#160;</tspan>
        <tspan x="0.5" dy="1.2">MIICiDCCAeqgAwIBAgIJAJ/xjMI6FKOAMAkGByqGSM49BAEwXjELMAkGA1UEBhMC</tspan>
        <tspan x="0.5" dy="1.2">VVMxCzAJBgNVBAgTAkNBMRAwDgYDVQQKEwdjZXJ0aWdvMRAwDgYDVQQLEwdleGFt</tspan>
        <tspan x="0.5" dy="1.2">cGxlMR4wHAYDVQQDExVleGFtcGxlLWVsbGlwdGljLXNoYTEwHhcNMTYwNjIyMDAy</tspan>
@@ -29,10 +25,6 @@
        <tspan x="0.5" dy="1.2">QqF02WtegKS3Kr6M7R8fn2QvsdzOPqlcN57E2Q==</tspan>
        <tspan x="0.5" dy="1.2">-----END CERTIFICATE-----</tspan>
        <tspan x="0.5" dy="1.2">-----BEGIN PRIVATE KEY-----</tspan>
-       <tspan x="0.5" dy="1.2">friendlyName: example-elliptic-sha1</tspan>
-       <tspan x="0.5" dy="1.2">localKeyId: dd50ce5c559b63733fbd0f6f95ce4d7527777698</tspan>
-       <tspan x="0.5" dy="1.2">originFile: keystore.p12</tspan>
-       <tspan x="0.5" dy="1.2">&#160;</tspan>
        <tspan x="0.5" dy="1.2">MIHcAgEBBEIBc4MT0rgcDEaimeP7Bxlhp3hAI2/KySFbOu6cg40taVXhXnaDAPqV</tspan>
        <tspan x="0.5" dy="1.2">tKj3kru+1DhvxBCrUewzKo5u9g+OC7xdu8qgBwYFK4EEACOhgYkDgYYABAEQWNjT</tspan>
        <tspan x="0.5" dy="1.2">8/MemDSwPVJD6T0qDTPibCzuoIsk7iMEctY9jzfeG5j0WXL33xTB6NIwW6H/7hBG</tspan>

--- a/main.go
+++ b/main.go
@@ -89,6 +89,7 @@ func main() {
 		i := 0
 		readCerts(files, func(block *pem.Block) {
 			if *dumpPem {
+				block.Headers = nil
 				pem.Encode(os.Stdout, block)
 				return
 			}
@@ -307,7 +308,7 @@ func readCertsFromFile(reader io.Reader, filename string, format string, callbac
 		password := readPassword("Enter password: ")
 		blocks, err := pkcs12.ToPEM(data, password)
 		if err != nil || len(blocks) == 0 {
-			fmt.Fprint(os.Stderr, "keystore appears to be empty or password was incorrect")
+			fmt.Fprint(os.Stderr, "keystore appears to be empty or password was incorrect\n")
 			os.Exit(1)
 		}
 		for _, block := range blocks {

--- a/tests/export-jceks.t
+++ b/tests/export-jceks.t
@@ -53,9 +53,6 @@ Dump PEM blocks from a JCEKS keystore.
 
   $ certigo dump --pem --password password example.jceks
   -----BEGIN RSA PRIVATE KEY-----
-  friendlyName: example-root
-  originFile: example.jceks
-  
   MIIEpQIBAAKCAQEAyjhKEojYzEPP81BXEFvPS1sPlHk1yhsDQ0qRo8ovIwSmdZVj
   25zJq4yOg2fUXnrxx86gXSmbfvTRTxRM+3YwzEQciLiYUb84XxQX5WiHUnjZNvja
   VGhblFFHeiCHj7tAHUb3ifGRh10cAnhAyFQmUuKAWDxzoV/8zFg4PL0juKUsU4xn
@@ -83,9 +80,6 @@ Dump PEM blocks from a JCEKS keystore.
   OcNCwOR/omok5c6d1Yje4MI4tpx5U4xqbSpO9AGat3flt/amjshl+94=
   -----END RSA PRIVATE KEY-----
   -----BEGIN CERTIFICATE-----
-  friendlyName: example-root
-  originFile: example.jceks
-  
   MIIDUzCCAjugAwIBAgIJAKg+LQlirffwMA0GCSqGSIb3DQEBCwUAMFUxCzAJBgNV
   BAYTAlVTMQswCQYDVQQIEwJDQTEQMA4GA1UEChMHY2VydGlnbzEQMA4GA1UECxMH
   ZXhhbXBsZTEVMBMGA1UEAxMMZXhhbXBsZS1yb290MB4XDTE2MDYxMDIyMTQxMVoX

--- a/tests/export-pkcs12.t
+++ b/tests/export-pkcs12.t
@@ -60,10 +60,6 @@ Dump PEM blocks from a PKCS12 keystore.
 
   $ certigo dump --pem --password password example.p12
   -----BEGIN CERTIFICATE-----
-  friendlyName: example-expired
-  localKeyId: ba95b425d439cd6903f9d002c7b0b91d94df3a3f
-  originFile: example.p12
-  
   MIIDLDCCAhQCCQCa74bQsAj2/jANBgkqhkiG9w0BAQsFADBYMQswCQYDVQQGEwJV
   UzELMAkGA1UECBMCQ0ExEDAOBgNVBAoTB2NlcnRpZ28xEDAOBgNVBAsTB2V4YW1w
   bGUxGDAWBgNVBAMTD2V4YW1wbGUtZXhwaXJlZDAeFw0xNjA2MTAyMjE0MTJaFw0x
@@ -83,10 +79,6 @@ Dump PEM blocks from a PKCS12 keystore.
   YSv7SyFevNwDwcxcAq6uVitKi0YCqHiNZ7Ye3/BGRDUFpK2IASUo8YbXYNyA/6nu
   -----END CERTIFICATE-----
   -----BEGIN PRIVATE KEY-----
-  friendlyName: example-expired
-  localKeyId: ba95b425d439cd6903f9d002c7b0b91d94df3a3f
-  originFile: example.p12
-  
   MIIEowIBAAKCAQEAs6JY7Hm/NAsH3nuMOOSBno6WmwsTYEw3hk4eyprWiI/Npoia
   iZVCGahT8NAKqLDW5t9vgKz6c4ffi5/aQ2scichq3QS7pELAYlS4b+ey3dA6hj62
   MOTTO4Ad5bFbbRZG+Mdm2Ayvl6eV6catQhMvxt7aIoY9+bodyIYC1zZVqwQ5sOT+


### PR DESCRIPTION
@mcpherrinm @worldwise001 @stfinney 
Not all software supports extra headers. Notably, OpenSSL will be sad
and refuse to parse the PEM block. Fixes #89.