### PR TITLE
Add separate verify command to validate certificates

### DIFF
--- a/verify.go
+++ b/verify.go
@@ -40,7 +40,7 @@ func caBundle(caPath string) *x509.CertPool {
 	return bundle
 }
 
-func verifyChain(certs []*x509.Certificate, dnsName, caPath string) {
+func verifyChain(certs []*x509.Certificate, dnsName, caPath string) bool {
 	intermediates := x509.NewCertPool()
 	for i := 1; i < len(certs); i++ {
 		intermediates.AddCert(certs[i])
@@ -56,7 +56,7 @@ func verifyChain(certs []*x509.Certificate, dnsName, caPath string) {
 	if err != nil {
 		red.Printf("Failed to verify certificate chain:\n")
 		fmt.Printf("\t%s\n", err)
-		return
+		return false
 	}
 
 	green.Printf("Server certificates appear to be valid (found %d chains):\n", len(chains))
@@ -84,6 +84,7 @@ func verifyChain(certs []*x509.Certificate, dnsName, caPath string) {
 		}
 		fmt.Printf("[%d] %s\n", i, strings.Join(names, "\n\t=> "))
 	}
+	return true
 }
 
 func isSelfSigned(cert *x509.Certificate) bool {


### PR DESCRIPTION
Add separate verify command to validate certificates from a file/stdin.

```
# Get an example cert chain for testing
$ certigo connect --pem squareup.com:443 > example-chain.crt

# Verify cert chain against a name
$ ./certigo verify --name squareup.com < example-chain.crt
Server certificates appear to be valid (found 2 chains):
[0] www.squareup.com
	=> Entrust Certification Authority - L1M
	=> Entrust Root Certification Authority - G2 [self-signed]
[1] www.squareup.com
	=> Entrust Certification Authority - L1M
	=> Entrust Root Certification Authority - G2
	=> Entrust Root Certification Authority [self-signed] [SHA1-RSA]

# Example with invalid name
$ ./certigo verify --name google.com < example-chain.crt
Failed to verify certificate chain:
	x509: certificate is valid for www.squareup.com, squareup.com, account.squareup.com, mkt.com, www.mkt.com, market.squareup.com, gosq.com, www.gosq.com, gosq.co, www.gosq.co, not google.com
```