### PR TITLE
Add SMTP STARTTLS support 

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 	connectJSON     = connect.Flag("json", "Write output as machine-readable JSON format.").Bool()
 	connectCert     = connect.Flag("cert", "Client certificate chain for connecting to server (PEM).").ExistingFile()
 	connectKey      = connect.Flag("key", "Private key for client certificate, if not in same file (PEM).").ExistingFile()
-	connectStartTLS = connect.Flag("start-tls", "Enable StartTLS protocol (supports 'mysql' and 'postgres').").PlaceHolder("PROTOCOL").Enum("mysql", "postgres", "psql", "smtp")
+	connectStartTLS = connect.Flag("start-tls", "Enable StartTLS protocol (supports 'mysql', 'postgres' and 'smtp').").PlaceHolder("PROTOCOL").Enum("mysql", "postgres", "psql", "smtp")
 
 	verify       = app.Command("verify", "Verify a certificate chain from file/stdin against a name.")
 	verifyFile   = verify.Arg("file", "Certificate file to dump (or stdin if not specified).").ExistingFile()

--- a/main.go
+++ b/main.go
@@ -50,7 +50,7 @@ var (
 	connectJSON     = connect.Flag("json", "Write output as machine-readable JSON format.").Bool()
 	connectCert     = connect.Flag("cert", "Client certificate chain for connecting to server (PEM).").ExistingFile()
 	connectKey      = connect.Flag("key", "Private key for client certificate, if not in same file (PEM).").ExistingFile()
-	connectStartTLS = connect.Flag("start-tls", "Enable StartTLS protocol (supports 'mysql' and 'postgres').").PlaceHolder("PROTOCOL").Enum("mysql", "postgres", "psql")
+	connectStartTLS = connect.Flag("start-tls", "Enable StartTLS protocol (supports 'mysql' and 'postgres').").PlaceHolder("PROTOCOL").Enum("mysql", "postgres", "psql", "smtp")
 
 	verify       = app.Command("verify", "Verify a certificate chain from file/stdin against a name.")
 	verifyFile   = verify.Arg("file", "Certificate file to dump (or stdin if not specified).").ExistingFile()

--- a/main.go
+++ b/main.go
@@ -95,7 +95,11 @@ func main() {
 		}
 
 	case connect.FullCommand(): // Get certs by connecting to a server
-		connState := starttls.GetConnectionState(*connectStartTLS, *connectName, *connectTo, *connectCert, *connectKey)
+		connState, err := starttls.GetConnectionState(*connectStartTLS, *connectName, *connectTo, *connectCert, *connectKey)
+		if err != nil {
+			fmt.Fprint(os.Stderr, err.Error())
+			os.Exit(1)
+		}
 		for _, cert := range connState.PeerCertificates {
 			if *connectPem {
 				pem.Encode(os.Stdout, lib.EncodeX509ToPEM(cert, nil))

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -100,12 +100,10 @@ func GetConnectionState(connectStartTLS, connectName, connectTo, connectCert, co
 			return nil, err
 		}
 		smtpState, ok := client.TLSConnectionState()
-		if ok {
-			state = &smtpState
-		} else {
-			// This state is unexpected (we would have gotten an error from StartTLS)
-			err = fmt.Errorf("SMTP Connection isn't TLS")
+		if !ok {
+			panic("SMTP Connection isn't TLS after we successfully called StartTLS")
 		}
+		state = &smtpState
 	default:
 		return nil, fmt.Errorf("error connecting: unknown StartTLS protocol '%s'\n", connectStartTLS)
 	}

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -19,13 +19,12 @@ package starttls
 import (
 	"crypto/tls"
 	"fmt"
-	"os"
 
 	"github.com/square/certigo/starttls/mysql"
 	"github.com/square/certigo/starttls/psql"
 )
 
-func tlsConfigForConnect(connectName, connectCert, connectKey string) *tls.Config {
+func tlsConfigForConnect(connectName, connectCert, connectKey string) (*tls.Config, error) {
 	conf := &tls.Config{
 		// We verify later manually so we can print results
 		InsecureSkipVerify: true,
@@ -40,32 +39,42 @@ func tlsConfigForConnect(connectName, connectCert, connectKey string) *tls.Confi
 
 		cert, err := tls.LoadX509KeyPair(connectCert, keyFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "unable to read client certificate/key: %s\n", err)
-			os.Exit(1)
+			return nil, fmt.Errorf("unable to read client certificate/key: %s\n", err)
 		}
 
 		conf.Certificates = []tls.Certificate{cert}
 	}
 
-	return conf
+	return conf, nil
 }
 
-func GetConnectionState(connectStartTLS, connectName, connectTo, connectCert, connectKey string) *tls.ConnectionState {
+// GetConnectionState connects to a TLS server, returning the connection state.
+// Currently, connectStartTLS can be one of "mysql", "postgres" or "psql", or the empty string, which does a normal TLS
+// connection.  connectTo specifies the address to connect to. connectName sets SNI.  connectCert and connectKey are
+// client certs
+func GetConnectionState(connectStartTLS, connectName, connectTo, connectCert, connectKey string) (*tls.ConnectionState, error) {
 	var state *tls.ConnectionState
 	var err error
 
 	switch connectStartTLS {
 	case "":
-		conn, err := tls.Dial("tcp", connectTo, tlsConfigForConnect(connectName, connectCert, connectKey))
+		tlsConfig, err := tlsConfigForConnect(connectName, connectCert, connectKey)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error connecting: %v\n", err)
-			os.Exit(1)
+			return nil, err
+		}
+		conn, err := tls.Dial("tcp", connectTo, tlsConfig)
+		if err != nil {
+			return nil, fmt.Errorf("error connecting: %v\n", err)
 		}
 		defer conn.Close()
 		s := conn.ConnectionState()
 		state = &s
 	case "mysql":
-		mysql.RegisterTLSConfig("certigo", tlsConfigForConnect(connectName, connectCert, connectKey))
+		tlsConfig, err := tlsConfigForConnect(connectName, connectCert, connectKey)
+		if err != nil {
+			return nil, err
+		}
+		mysql.RegisterTLSConfig("certigo", tlsConfig)
 		state, err = mysql.DumpTLS(fmt.Sprintf("certigo@tcp(%s)/?tls=certigo", connectTo))
 	case "postgres", "psql":
 		// Setting sslmode to "require" skips verification.
@@ -78,14 +87,12 @@ func GetConnectionState(connectStartTLS, connectName, connectTo, connectCert, co
 		}
 		state, err = pq.DumpTLS(url)
 	default:
-		fmt.Fprintf(os.Stderr, "error connecting: unknown StartTLS protocol '%s'\n", connectStartTLS)
-		os.Exit(1)
+		return nil, fmt.Errorf("error connecting: unknown StartTLS protocol '%s'\n", connectStartTLS)
 	}
 
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error connecting: %v\n", err)
-		os.Exit(1)
+		return nil, fmt.Errorf("error connecting: %v\n", err)
 	}
 
-	return state
+	return state, nil
 }


### PR DESCRIPTION
Uses net/smtp, which is apparently frozen, but conveniently already has a TLSConnectionState() function.