### PR TITLE
Add support for coloured output on windows

### DIFF
--- a/main.go
+++ b/main.go
@@ -27,6 +27,7 @@ import (
 
 	"gopkg.in/alecthomas/kingpin.v2"
 
+	"github.com/mattn/go-colorable"
 	"github.com/square/certigo/lib"
 	"github.com/square/certigo/starttls"
 	"golang.org/x/crypto/ssh/terminal"
@@ -63,6 +64,7 @@ var (
 func main() {
 	app.Version("1.6.0")
 
+	stdout := colorable.NewColorableStdout()
 	result := simpleResult{}
 	switch kingpin.MustParse(app.Parse(os.Args[1:])) {
 	case dump.FullCommand(): // Dump certificate
@@ -88,8 +90,8 @@ func main() {
 				fmt.Println(string(blob))
 			} else {
 				for i, cert := range result.Certificates {
-					fmt.Printf("** CERTIFICATE %d **\n", i+1)
-					fmt.Printf("%s\n\n", lib.EncodeX509ToText(cert))
+					fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
+					fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert))
 				}
 			}
 		}
@@ -124,10 +126,10 @@ func main() {
 			fmt.Println(string(blob))
 		} else if !*connectPem {
 			for i, cert := range result.Certificates {
-				fmt.Printf("** CERTIFICATE %d **\n", i+1)
-				fmt.Printf("%s\n\n", lib.EncodeX509ToText(cert))
+				fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
+				fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert))
 			}
-			printVerifyResult(*result.VerifyResult)
+			printVerifyResult(stdout, *result.VerifyResult)
 		}
 	case verify.FullCommand():
 		file := inputFile(*verifyFile)
@@ -143,7 +145,7 @@ func main() {
 			blob, _ := json.Marshal(verifyResult)
 			fmt.Println(string(blob))
 		} else {
-			printVerifyResult(verifyResult)
+			printVerifyResult(stdout, verifyResult)
 		}
 		if verifyResult.Error != "" {
 			os.Exit(1)

--- a/verify.go
+++ b/verify.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"encoding/pem"
 	"fmt"
+	"io"
 	"io/ioutil"
 	"os"
 	"strconv"
@@ -170,19 +171,19 @@ func algString(algo x509.SignatureAlgorithm) string {
 	return strconv.Itoa(int(algo))
 }
 
-func printVerifyResult(result simpleVerification) {
+func printVerifyResult(out io.Writer, result simpleVerification) {
 	if result.Error != "" {
-		red.Printf("Failed to verify certificate chain:\n")
-		fmt.Printf("\t%s\n", result.Error)
+		fmt.Fprintf(out, red.SprintfFunc()("Failed to verify certificate chain:\n"))
+		fmt.Fprintf(out, "\t%s\n", result.Error)
 		return
 	}
 	for i, chain := range result.Chains {
-		fmt.Printf("[%d] %s\n", i, fmtCert(chain[0]))
+		fmt.Fprintf(out, "[%d] %s\n", i, fmtCert(chain[0]))
 		for j, cert := range chain {
 			if j == 0 {
 				continue
 			}
-			fmt.Printf("\t=> %s\n", fmtCert(cert))
+			fmt.Fprintf(out, "\t=> %s\n", fmtCert(cert))
 		}
 	}
 }


### PR DESCRIPTION
This is pulled in as a dependency of fatih/color, but the way we were printing output wasn't automatically compatible with Windows.

This makes our colored output explicitly go through a colorable stdout handle.