### PR TITLE
Nicer output for verified chains

### DIFF
--- a/main.go
+++ b/main.go
@@ -98,7 +98,7 @@ func main() {
 	case connect.FullCommand(): // Get certs by connecting to a server
 		connState, err := starttls.GetConnectionState(*connectStartTLS, *connectName, *connectTo, *connectCert, *connectKey)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s\n", err.Error())
+			fmt.Fprintf(os.Stderr, "%s\n", strings.TrimSuffix(err.Error(), "\n"))
 			os.Exit(1)
 		}
 		for _, cert := range connState.PeerCertificates {

--- a/verify.go
+++ b/verify.go
@@ -177,6 +177,7 @@ func printVerifyResult(out io.Writer, result simpleVerification) {
 		fmt.Fprintf(out, "\t%s\n", result.Error)
 		return
 	}
+	fmt.Fprintf(out, green.SprintfFunc()("Found %d valid certificate chain(s):\n", len(result.Chains)))
 	for i, chain := range result.Chains {
 		fmt.Fprintf(out, "[%d] %s\n", i, fmtCert(chain[0]))
 		for j, cert := range chain {


### PR DESCRIPTION
* Print a message before verified chains to make output a bit more readable
* Strip newlines from errors so we don't have double-newlines (some errors end with \n, others don't)