### PR TITLE
Make text certs shorter, existing text output now has a --verbose flag

### DIFF
--- a/lib/display.go
+++ b/lib/display.go
@@ -40,8 +40,7 @@ var verboseLayout = `
 
 {{- if .Alias}}{{.Alias}}
 {{end}}Serial: {{.SerialNumber}}
-Not Before: {{.NotBefore | certStart}}
-Not After : {{.NotAfter | certEnd}}
+Valid: {{.NotBefore | certStart}} to {{.NotAfter | certEnd}}
 Signature : {{.SignatureAlgorithm | highlightAlgorithm}}{{if .IsSelfSigned}} (self-signed){{end}}
 Subject Info:
 	{{- template "PkixName" .Subject.Name}}

--- a/lib/display.go
+++ b/lib/display.go
@@ -69,8 +69,7 @@ Warnings:{{range .Warnings}}
 var layout = `
 {{- if .Alias}}{{.Alias}}
 {{end -}}
-Not Before: {{.NotBefore | certStart}}
-Not After : {{.NotAfter | certEnd}}
+Valid: {{.NotBefore | certStart}} to {{.NotAfter | certEnd}}
 Subject: {{.Subject.Name | printName }}
 Issuer: {{.Issuer.Name | printName }}
 {{- if .NameConstraints}}

--- a/lib/display.go
+++ b/lib/display.go
@@ -41,14 +41,14 @@ var verboseLayout = `
 {{- if .Alias}}{{.Alias}}
 {{end}}Serial: {{.SerialNumber}}
 Valid: {{.NotBefore | certStart}} to {{.NotAfter | certEnd}}
-Signature : {{.SignatureAlgorithm | highlightAlgorithm}}{{if .IsSelfSigned}} (self-signed){{end}}
+Signature: {{.SignatureAlgorithm | highlightAlgorithm}}{{if .IsSelfSigned}} (self-signed){{end}}
 Subject Info:
 	{{- template "PkixName" .Subject.Name}}
 Issuer Info:
 	{{- template "PkixName" .Issuer.Name}}
 {{- if .Subject.KeyID}}
-Subject Key ID   : {{.Subject.KeyID | hexify}}{{end}}{{if .Issuer.KeyID}}
-Authority Key ID : {{.Issuer.KeyID | hexify}}{{end}}{{if .BasicConstraints}}
+Subject Key ID: {{.Subject.KeyID | hexify}}{{end}}{{if .Issuer.KeyID}}
+Authority Key ID: {{.Issuer.KeyID | hexify}}{{end}}{{if .BasicConstraints}}
 Basic Constraints: CA:{{.BasicConstraints.IsCA}}{{if .BasicConstraints.MaxPathLen}}, pathlen:{{.BasicConstraints.MaxPathLen}}{{end}}{{end}}{{if .NameConstraints}}
 Name Constraints {{if .PermittedDNSDomains.Critical}}(critical){{end}}: {{range .NameConstraints.PermittedDNSDomains}}
 	{{.}}{{end}}{{end}}{{if .KeyUsage}}
@@ -72,7 +72,7 @@ Valid: {{.NotBefore | certStart}} to {{.NotAfter | certEnd}}
 Subject: {{.Subject.Name | printName }}
 Issuer: {{.Issuer.Name | printName }}
 {{- if .NameConstraints}}
-Name Constraints {{if .PermittedDNSDomains.Critical}}(critical){{end}}: {{range .NameConstraints.PermittedDNSDomains}}
+Name Constraints{{if .PermittedDNSDomains.Critical}} (critical){{end}}: {{range .NameConstraints.PermittedDNSDomains}}
 	{{.}}{{end}}{{end}}
 {{- if .AltDNSNames}}
 Alternate DNS Names:{{range .AltDNSNames}}

--- a/lib/display.go
+++ b/lib/display.go
@@ -207,6 +207,11 @@ func highlightAlgorithm(sigAlg simpleSigAlg) string {
 	return color.SprintFunc()(algString(sig))
 }
 
+// timeString formats a time in UTC with minute precision, in the given color.
+func timeString(t time.Time, c *color.Color) string {
+	return c.SprintfFunc()(t.Format("2006-01-02 15:04Z"))
+}
+
 // certStart takes a given start time for the validity of
 // a certificate and returns that time colored properly
 // based on how close it is to expiry. If it's more than
@@ -219,11 +224,11 @@ func certStart(start time.Time) string {
 	day, _ := time.ParseDuration("24h")
 	threshold := start.Add(day)
 	if now.After(threshold) {
-		return green.SprintfFunc()(start.String())
+		return timeString(start, green)
 	} else if now.After(start) {
-		return yellow.SprintfFunc()(start.String())
+		return timeString(start, yellow)
 	} else {
-		return red.SprintfFunc()(start.String())
+		return timeString(start, red)
 	}
 }
 
@@ -239,11 +244,11 @@ func certEnd(end time.Time) string {
 	month, _ := time.ParseDuration("720h")
 	threshold := now.Add(month)
 	if threshold.Before(end) {
-		return green.SprintfFunc()(end.String())
+		return timeString(end, green)
 	} else if now.Before(end) {
-		return yellow.SprintfFunc()(end.String())
+		return timeString(end, yellow)
 	} else {
-		return red.SprintfFunc()(end.String())
+		return timeString(end, red)
 	}
 }
 

--- a/lib/display.go
+++ b/lib/display.go
@@ -209,7 +209,7 @@ func highlightAlgorithm(sigAlg simpleSigAlg) string {
 
 // timeString formats a time in UTC with minute precision, in the given color.
 func timeString(t time.Time, c *color.Color) string {
-	return c.SprintfFunc()(t.Format("2006-01-02 15:04Z"))
+	return c.SprintfFunc()(t.Format("2006-01-02 15:04 MST"))
 }
 
 // certStart takes a given start time for the validity of

--- a/lib/oids.go
+++ b/lib/oids.go
@@ -2,10 +2,11 @@ package lib
 
 import "encoding/asn1"
 
-// OidDescription returns a human-readable name, a snake_case slug suitable as a json key,
+// OidDescription returns a human-readable name, a short acronym from RFC1485, a snake_case slug suitable as a json key,
 // and a boolean describing whether multiple copies can appear on an X509 cert.
 type OidDescription struct {
 	Name     string
+	Short    string
 	Slug     string
 	Multiple bool
 }
@@ -14,21 +15,29 @@ func describeOid(oid asn1.ObjectIdentifier) OidDescription {
 	raw := oid.String()
 	// Multiple should be true for any types that are []string in x509.pkix.Name. When in doubt, set it to true.
 	names := map[string]OidDescription{
-		"2.5.4.3":                  {"CommonName", "common_name", false},
-		"2.5.4.5":                  {"EV Incorporation Registration Number", "ev_registration_number", false},
-		"2.5.4.6":                  {"Country", "country", true},
-		"2.5.4.7":                  {"Locality", "locality", true},
-		"2.5.4.8":                  {"Province", "province", true},
-		"2.5.4.10":                 {"Organization", "organization", true},
-		"2.5.4.11":                 {"Organizational Unit", "organizational_unit", true},
-		"2.5.4.15":                 {"Business Category", "business_category", true},
-		"1.2.840.113549.1.9.1":     {"Email Address", "email_address", true},
-		"1.3.6.1.4.1.311.60.2.1.1": {"EV Incorporation Locality", "ev_locality", true},
-		"1.3.6.1.4.1.311.60.2.1.2": {"EV Incorporation Province", "ev_province", true},
-		"1.3.6.1.4.1.311.60.2.1.3": {"EV Incorporation Country", "ev_country", true},
+		"2.5.4.3":                  {"CommonName", "CN", "common_name", false},
+		"2.5.4.5":                  {"EV Incorporation Registration Number", "", "ev_registration_number", false},
+		"2.5.4.6":                  {"Country", "C", "country", true},
+		"2.5.4.7":                  {"Locality", "L", "locality", true},
+		"2.5.4.8":                  {"Province", "ST", "province", true},
+		"2.5.4.10":                 {"Organization", "O", "organization", true},
+		"2.5.4.11":                 {"Organizational Unit", "OU", "organizational_unit", true},
+		"2.5.4.15":                 {"Business Category", "", "business_category", true},
+		"1.2.840.113549.1.9.1":     {"Email Address", "", "email_address", true},
+		"1.3.6.1.4.1.311.60.2.1.1": {"EV Incorporation Locality", "", "ev_locality", true},
+		"1.3.6.1.4.1.311.60.2.1.2": {"EV Incorporation Province", "", "ev_province", true},
+		"1.3.6.1.4.1.311.60.2.1.3": {"EV Incorporation Country", "", "ev_country", true},
 	}
 	if description, ok := names[raw]; ok {
 		return description
 	}
-	return OidDescription{raw, raw, true}
+	return OidDescription{raw, "", raw, true}
+}
+
+func oidShort(oid asn1.ObjectIdentifier) string {
+	return describeOid(oid).Short
+}
+
+func oidName(oid asn1.ObjectIdentifier) string {
+	return describeOid(oid).Name
 }

--- a/main.go
+++ b/main.go
@@ -33,7 +33,8 @@ import (
 )
 
 var (
-	app = kingpin.New("certigo", "A command line certificate examination utility.")
+	app     = kingpin.New("certigo", "A command line certificate examination utility.")
+	verbose = app.Flag("verbose", "Print verbose").Short('v').Bool()
 
 	dump         = app.Command("dump", "Display information about a certificate from a file/stdin.")
 	dumpFiles    = dump.Arg("file", "Certificate file to dump (or stdin if not specified).").ExistingFiles()
@@ -91,7 +92,7 @@ func main() {
 			} else {
 				for i, cert := range result.Certificates {
 					fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
-					fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert))
+					fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert, *verbose))
 				}
 			}
 		}
@@ -129,7 +130,7 @@ func main() {
 			fmt.Fprintf(stdout, "%s\n\n", lib.EncodeTLSToText(result.TLSConnectionState))
 			for i, cert := range result.Certificates {
 				fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
-				fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert))
+				fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert, *verbose))
 			}
 			printVerifyResult(stdout, *result.VerifyResult)
 		}

--- a/tests/dump-cert-chain-to-text.t
+++ b/tests/dump-cert-chain-to-text.t
@@ -107,7 +107,7 @@ Set up test data.
 
 Dump a live cert chain (squareup-chain.crt)
 
-  $ certigo dump squareup-chain.crt
+  $ certigo --verbose dump squareup-chain.crt
   ** CERTIFICATE 1 **
   Serial: 260680855742043049380997676879525498489
   Not Before: 2016-07-15 20:15:52 +0000 UTC

--- a/tests/dump-cert-chain-to-text.t
+++ b/tests/dump-cert-chain-to-text.t
@@ -110,8 +110,7 @@ Dump a live cert chain (squareup-chain.crt)
   $ certigo --verbose dump squareup-chain.crt
   ** CERTIFICATE 1 **
   Serial: 260680855742043049380997676879525498489
-  Not Before: 2016-07-15 20:15:52 +0000 UTC
-  Not After : 2017-07-31 20:45:50 +0000 UTC
+  Valid: 2016-07-15 20:15 UTC to 2017-07-31 20:45 UTC
   Signature : SHA256-RSA
   Subject Info:
   \tCountry: US (esc)
@@ -152,8 +151,7 @@ Dump a live cert chain (squareup-chain.crt)
   
   ** CERTIFICATE 2 **
   Serial: 30215777750102225331854468774
-  Not Before: 2014-12-15 15:25:03 +0000 UTC
-  Not After : 2030-10-15 15:55:03 +0000 UTC
+  Valid: 2014-12-15 15:25 UTC to 2030-10-15 15:55 UTC
   Signature : SHA256-RSA
   Subject Info:
   \tCountry: US (esc)
@@ -179,8 +177,7 @@ Dump a live cert chain (squareup-chain.crt)
   
   ** CERTIFICATE 3 **
   Serial: 1372799044
-  Not Before: 2014-09-22 17:14:57 +0000 UTC
-  Not After : 2024-09-23 01:31:53 +0000 UTC
+  Valid: 2014-09-22 17:14 UTC to 2024-09-23 01:31 UTC
   Signature : SHA256-RSA
   Subject Info:
   \tCountry: US (esc)

--- a/tests/dump-cert-chain-to-text.t
+++ b/tests/dump-cert-chain-to-text.t
@@ -111,7 +111,7 @@ Dump a live cert chain (squareup-chain.crt)
   ** CERTIFICATE 1 **
   Serial: 260680855742043049380997676879525498489
   Valid: 2016-07-15 20:15 UTC to 2017-07-31 20:45 UTC
-  Signature : SHA256-RSA
+  Signature: SHA256-RSA
   Subject Info:
   \tCountry: US (esc)
   \tProvince: California (esc)
@@ -128,8 +128,8 @@ Dump a live cert chain (squareup-chain.crt)
   \tOrganizational Unit: See www.entrust.net/legal-terms (esc)
   \tOrganizational Unit: (c) 2014 Entrust, Inc. - for authorized use only (esc)
   \tCommonName: Entrust Certification Authority - L1M (esc)
-  Subject Key ID   : D4:17:14:6F:0B:C5:20:A1:D6:FE:21:7E:DC:9E:F8:57:9C:ED:AE:6A
-  Authority Key ID : C3:F7:D0:B5:2A:30:AD:AF:0D:91:21:70:39:54:DD:BC:89:70:C7:3A
+  Subject Key ID: D4:17:14:6F:0B:C5:20:A1:D6:FE:21:7E:DC:9E:F8:57:9C:ED:AE:6A
+  Authority Key ID: C3:F7:D0:B5:2A:30:AD:AF:0D:91:21:70:39:54:DD:BC:89:70:C7:3A
   Basic Constraints: CA:false
   Key Usage:
   \tDigital Signature (esc)
@@ -152,7 +152,7 @@ Dump a live cert chain (squareup-chain.crt)
   ** CERTIFICATE 2 **
   Serial: 30215777750102225331854468774
   Valid: 2014-12-15 15:25 UTC to 2030-10-15 15:55 UTC
-  Signature : SHA256-RSA
+  Signature: SHA256-RSA
   Subject Info:
   \tCountry: US (esc)
   \tOrganization: Entrust, Inc. (esc)
@@ -165,8 +165,8 @@ Dump a live cert chain (squareup-chain.crt)
   \tOrganizational Unit: See www.entrust.net/legal-terms (esc)
   \tOrganizational Unit: (c) 2009 Entrust, Inc. - for authorized use only (esc)
   \tCommonName: Entrust Root Certification Authority - G2 (esc)
-  Subject Key ID   : C3:F7:D0:B5:2A:30:AD:AF:0D:91:21:70:39:54:DD:BC:89:70:C7:3A
-  Authority Key ID : 6A:72:26:7A:D0:1E:EF:7D:E7:3B:69:51:D4:6C:8D:9F:90:12:66:AB
+  Subject Key ID: C3:F7:D0:B5:2A:30:AD:AF:0D:91:21:70:39:54:DD:BC:89:70:C7:3A
+  Authority Key ID: 6A:72:26:7A:D0:1E:EF:7D:E7:3B:69:51:D4:6C:8D:9F:90:12:66:AB
   Basic Constraints: CA:true, pathlen:0
   Key Usage:
   \tCert Sign (esc)
@@ -178,7 +178,7 @@ Dump a live cert chain (squareup-chain.crt)
   ** CERTIFICATE 3 **
   Serial: 1372799044
   Valid: 2014-09-22 17:14 UTC to 2024-09-23 01:31 UTC
-  Signature : SHA256-RSA
+  Signature: SHA256-RSA
   Subject Info:
   \tCountry: US (esc)
   \tOrganization: Entrust, Inc. (esc)
@@ -191,8 +191,8 @@ Dump a live cert chain (squareup-chain.crt)
   \tOrganizational Unit: www.entrust.net/CPS is incorporated by reference (esc)
   \tOrganizational Unit: (c) 2006 Entrust, Inc. (esc)
   \tCommonName: Entrust Root Certification Authority (esc)
-  Subject Key ID   : 6A:72:26:7A:D0:1E:EF:7D:E7:3B:69:51:D4:6C:8D:9F:90:12:66:AB
-  Authority Key ID : 68:90:E4:67:A4:A6:53:80:C7:86:66:A4:F1:F7:4B:43:FB:84:BD:6D
+  Subject Key ID: 6A:72:26:7A:D0:1E:EF:7D:E7:3B:69:51:D4:6C:8D:9F:90:12:66:AB
+  Authority Key ID: 68:90:E4:67:A4:A6:53:80:C7:86:66:A4:F1:F7:4B:43:FB:84:BD:6D
   Basic Constraints: CA:true, pathlen:1
   Key Usage:
   \tCert Sign (esc)

--- a/tests/dump-jceks-to-pem.t
+++ b/tests/dump-jceks-to-pem.t
@@ -51,7 +51,7 @@ Set up test data.
 
 Dump PEM blocks from a JCEKS keystore.
 
-  $ certigo dump --pem --password password example.jceks
+  $ certigo --verbose dump --pem --password password example.jceks
   -----BEGIN RSA PRIVATE KEY-----
   MIIEpQIBAAKCAQEAyjhKEojYzEPP81BXEFvPS1sPlHk1yhsDQ0qRo8ovIwSmdZVj
   25zJq4yOg2fUXnrxx86gXSmbfvTRTxRM+3YwzEQciLiYUb84XxQX5WiHUnjZNvja

--- a/tests/dump-leaf-to-not-verbose.t
+++ b/tests/dump-leaf-to-not-verbose.t
@@ -28,7 +28,7 @@ Dump an example certificate (example-leaf.crt)
 
   $ certigo dump example-leaf.crt
   ** CERTIFICATE 1 **
-  Valid: 2016-06-10 22:14:11 +0000 UTC to 2023-04-15 22:14:11 +0000 UTC
+  Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
   Subject: C=US, ST=CA, O=certigo, OU=example, CN=example-leaf
   Issuer: C=US, ST=CA, O=certigo, OU=example, CN=example-leaf
   Alternate DNS Names:

--- a/tests/dump-leaf-to-not-verbose.t
+++ b/tests/dump-leaf-to-not-verbose.t
@@ -26,27 +26,12 @@ Set up test data.
 
 Dump an example certificate (example-leaf.crt)
 
-  $ certigo --verbose dump example-leaf.crt
+  $ certigo dump example-leaf.crt
   ** CERTIFICATE 1 **
-  Serial: 15384458167827828543
   Not Before: 2016-06-10 22:14:11 +0000 UTC
   Not After : 2023-04-15 22:14:11 +0000 UTC
-  Signature : SHA256-RSA
-  Subject Info:
-  \tCountry: US (esc)
-  \tProvince: CA (esc)
-  \tOrganization: certigo (esc)
-  \tOrganizational Unit: example (esc)
-  \tCommonName: example-leaf (esc)
-  Issuer Info:
-  \tCountry: US (esc)
-  \tProvince: CA (esc)
-  \tOrganization: certigo (esc)
-  \tOrganizational Unit: example (esc)
-  \tCommonName: example-leaf (esc)
-  Extended Key Usage:
-  \tClient Auth (esc)
-  \tServer Auth (esc)
+  Subject: C=US, ST=CA, O=certigo, OU=example, CN=example-leaf
+  Issuer: C=US, ST=CA, O=certigo, OU=example, CN=example-leaf
   Alternate DNS Names:
   \tlocalhost (esc)
   Alternate IP Addresses:

--- a/tests/dump-leaf-to-not-verbose.t
+++ b/tests/dump-leaf-to-not-verbose.t
@@ -28,8 +28,7 @@ Dump an example certificate (example-leaf.crt)
 
   $ certigo dump example-leaf.crt
   ** CERTIFICATE 1 **
-  Not Before: 2016-06-10 22:14:11 +0000 UTC
-  Not After : 2023-04-15 22:14:11 +0000 UTC
+  Valid: 2016-06-10 22:14:11 +0000 UTC to 2023-04-15 22:14:11 +0000 UTC
   Subject: C=US, ST=CA, O=certigo, OU=example, CN=example-leaf
   Issuer: C=US, ST=CA, O=certigo, OU=example, CN=example-leaf
   Alternate DNS Names:

--- a/tests/dump-leaf-to-text.t
+++ b/tests/dump-leaf-to-text.t
@@ -29,8 +29,7 @@ Dump an example certificate (example-leaf.crt)
   $ certigo --verbose dump example-leaf.crt
   ** CERTIFICATE 1 **
   Serial: 15384458167827828543
-  Not Before: 2016-06-10 22:14:11 +0000 UTC
-  Not After : 2023-04-15 22:14:11 +0000 UTC
+  Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
   Signature : SHA256-RSA
   Subject Info:
   \tCountry: US (esc)

--- a/tests/dump-leaf-to-text.t
+++ b/tests/dump-leaf-to-text.t
@@ -30,7 +30,7 @@ Dump an example certificate (example-leaf.crt)
   ** CERTIFICATE 1 **
   Serial: 15384458167827828543
   Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
-  Signature : SHA256-RSA
+  Signature: SHA256-RSA
   Subject Info:
   \tCountry: US (esc)
   \tProvince: CA (esc)

--- a/tests/dump-pkcs12-to-pem.t
+++ b/tests/dump-pkcs12-to-pem.t
@@ -58,7 +58,7 @@ Set up test data.
 
 Dump PEM blocks from a PKCS12 keystore.
 
-  $ certigo dump --pem --password password example.p12
+  $ certigo --verbose dump --pem --password password example.p12
   -----BEGIN CERTIFICATE-----
   MIIDLDCCAhQCCQCa74bQsAj2/jANBgkqhkiG9w0BAQsFADBYMQswCQYDVQQGEwJV
   UzELMAkGA1UECBMCQ0ExEDAOBgNVBAoTB2NlcnRpZ28xEDAOBgNVBAsTB2V4YW1w

--- a/tests/dump-small-key-to-text.t
+++ b/tests/dump-small-key-to-text.t
@@ -22,8 +22,7 @@ Dump an example certificate (example-leaf.crt)
   $ certigo --verbose dump example-small-key.crt
   ** CERTIFICATE 1 **
   Serial: 14381893493177441266
-  Not Before: 2016-06-10 22:14:12 +0000 UTC
-  Not After : 2023-04-15 22:14:12 +0000 UTC
+  Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
   Signature : SHA256-RSA (self-signed)
   Subject Info:
   \tCountry: US (esc)

--- a/tests/dump-small-key-to-text.t
+++ b/tests/dump-small-key-to-text.t
@@ -19,7 +19,7 @@ Set up test data.
 
 Dump an example certificate (example-leaf.crt)
 
-  $ certigo dump example-small-key.crt
+  $ certigo --verbose dump example-small-key.crt
   ** CERTIFICATE 1 **
   Serial: 14381893493177441266
   Not Before: 2016-06-10 22:14:12 +0000 UTC

--- a/tests/dump-small-key-to-text.t
+++ b/tests/dump-small-key-to-text.t
@@ -23,7 +23,7 @@ Dump an example certificate (example-leaf.crt)
   ** CERTIFICATE 1 **
   Serial: 14381893493177441266
   Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
-  Signature : SHA256-RSA (self-signed)
+  Signature: SHA256-RSA (self-signed)
   Subject Info:
   \tCountry: US (esc)
   \tProvince: CA (esc)


### PR DESCRIPTION
This gets rid of a lot of information that I think I don't care about most of the time, in my experience debugging TLS.  We print not before / not after, subject, issuer, name constraints, SANS, and warnings.

there's a new --verbose flag that prints the old output.

Sample output: 

```
./certigo connect squareup.com:443
** TLS Connection **
Version: TLS 1.2
Cipher Suite: ECDHE_RSA key exchange, AES_128_GCM_SHA256 cipher
** CERTIFICATE 1 **
Valid: 2016-06-10 22:14 UTC to 2017-07-31 20:45 UTC
Subject: C=US, ST=California, L=San Francisco, , , O=Square, Inc., CN=www.squareup.com
Issuer: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2014 Entrust, Inc. - for authorized use only, CN=Entrust Certification Authority - L1M
Alternate DNS Names:
        www.squareup.com
        squareup.com
        account.squareup.com
        mkt.com
        www.mkt.com
        market.squareup.com
        gosq.com
        www.gosq.com
        gosq.co
        www.gosq.co

** CERTIFICATE 2 **
Valid: 2014-12-15 15:25 UTC to 2030-10-15 15:55 UTC
Subject: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2014 Entrust, Inc. - for authorized use only, CN=Entrust Certification Authority - L1M
Issuer: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2009 Entrust, Inc. - for authorized use only, CN=Entrust Root Certification Authority - G2

** CERTIFICATE 3 **
Not Before: 2014-09-22 17:14 UTC to 2024-09-23 01:31 UTC
Subject: C=US, O=Entrust, Inc., OU=See www.entrust.net/legal-terms, OU=(c) 2009 Entrust, Inc. - for authorized use only, CN=Entrust Root Certification Authority - G2
Issuer: C=US, O=Entrust, Inc., OU=www.entrust.net/CPS is incorporated by reference, OU=(c) 2006 Entrust, Inc., CN=Entrust Root Certification Authority

Found 2 valid certificate chain(s):
[0] www.squareup.com
        => Entrust Certification Authority - L1M
        => Entrust Root Certification Authority - G2 [self-signed]
[1] www.squareup.com
        => Entrust Certification Authority - L1M
        => Entrust Root Certification Authority - G2
        => Entrust Root Certification Authority [self-signed] [SHA1-RSA]
```