### PR TITLE
Support connect timeouts

### DIFF
--- a/main.go
+++ b/main.go
@@ -50,6 +50,7 @@ var (
 	connectCert     = connect.Flag("cert", "Client certificate chain for connecting to server (PEM).").ExistingFile()
 	connectKey      = connect.Flag("key", "Private key for client certificate, if not in same file (PEM).").ExistingFile()
 	connectStartTLS = connect.Flag("start-tls", "Enable StartTLS protocol ('ldap', 'mysql', 'postgres', 'smtp' or 'ftp').").Short('t').PlaceHolder("PROTOCOL").Enum("mysql", "postgres", "psql", "smtp", "ldap", "ftp")
+	connectTimeout  = connect.Flag("timeout", "Timeout for connecting to remote server (can be '5m', '1s', etc).").Default("5s").Duration()
 	connectPem      = connect.Flag("pem", "Write output as PEM blocks instead of human-readable format.").Short('m').Bool()
 	connectJSON     = connect.Flag("json", "Write output as machine-readable JSON format.").Short('j').Bool()
 
@@ -98,7 +99,7 @@ func main() {
 		}
 
 	case connect.FullCommand(): // Get certs by connecting to a server
-		connState, err := starttls.GetConnectionState(*connectStartTLS, *connectName, *connectTo, *connectCert, *connectKey)
+		connState, err := starttls.GetConnectionState(*connectStartTLS, *connectName, *connectTo, *connectCert, *connectKey, *connectTimeout)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", strings.TrimSuffix(err.Error(), "\n"))
 			os.Exit(1)

--- a/starttls/ftp.go
+++ b/starttls/ftp.go
@@ -25,8 +25,8 @@ import (
 	"strings"
 )
 
-func dumpAuthTLSFromFTP(address string, config *tls.Config) (*tls.ConnectionState, error) {
-	c, err := net.Dial("tcp", address)
+func dumpAuthTLSFromFTP(dialer *net.Dialer, address string, config *tls.Config) (*tls.ConnectionState, error) {
+	c, err := dialer.Dial("tcp", address)
 	if err != nil {
 		return nil, err
 	}

--- a/starttls/ldap/conn.go
+++ b/starttls/ldap/conn.go
@@ -110,8 +110,8 @@ var DefaultTimeout = 60 * time.Second
 
 // Dial connects to the given address on the given network using net.Dial
 // and then returns a new Conn for the connection.
-func Dial(network, addr string) (*Conn, error) {
-	c, err := net.DialTimeout(network, addr, DefaultTimeout)
+func Dial(network, addr string, timeout time.Duration) (*Conn, error) {
+	c, err := net.DialTimeout(network, addr, timeout)
 	if err != nil {
 		return nil, NewError(ErrorNetwork, err)
 	}


### PR DESCRIPTION
Support connect timeouts! Except for SMTP, because net/smtp doesn't support timeouts/deadlines. Could submit a patch to upstream, or fork. 