### PR TITLE
Remove JKS from readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Certigo is a utility to examine and validate certificates to help with debugging
 
 ### Features
 
-**Supports all common file formats**: Certigo can read and dump certificates in various formats. It can automatically detect and read from X.509 (DER/PEM), JCEKS/JKS, PKCS7 and PKCS12 files. Certificates can be dumped to a human-readable format, a set of PEM blocks, or a JSON object for use in scripting. 
+**Supports all common file formats**: Certigo can read and dump certificates in various formats. It can automatically detect and read from X.509 (DER/PEM), JCEKS, PKCS7 and PKCS12 files. Certificates can be dumped to a human-readable format, a set of PEM blocks, or a JSON object for use in scripting. 
 
 **Validation and linting**: Not sure if your generated certificate is valid? Certigo can connect to remote servers to display and validate their certificate chains. It can also point out common errors on certififcates, such as using an older X.509 format, signatures with outdated hashes, or keys that are too small. 
 


### PR DESCRIPTION
JKS doesn't actually work.

I'll look into why later, and can re-add it when fixed.