### PR TITLE
Add support for showing requested client certificate info

### DIFF
--- a/lib/display.go
+++ b/lib/display.go
@@ -161,7 +161,7 @@ func displayCert(cert simpleCertificate, verbose bool) []byte {
 		"extKeyUsage":        extKeyUsage,
 		"oidName":            oidName,
 		"oidShort":           oidShort,
-		"printShortName":     printShortName,
+		"printShortName":     PrintShortName,
 	}
 	for k, v := range extras {
 		funcMap[k] = v
@@ -270,7 +270,11 @@ func redify(text string) string {
 	return red.SprintfFunc()("%s", text)
 }
 
-func printShortName(name pkix.Name) (out string) {
+func greenify(text string) string {
+	return green.SprintfFunc()("%s", text)
+}
+
+func PrintShortName(name pkix.Name) (out string) {
 	// Try to print CN for short name if present.
 	if name.CommonName != "" {
 		return fmt.Sprintf("CN=%s", name.CommonName)

--- a/lib/encoder.go
+++ b/lib/encoder.go
@@ -21,6 +21,7 @@ import (
 	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/rsa"
+	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/hex"
@@ -43,6 +44,57 @@ var keyUsages = []x509.KeyUsage{
 	x509.KeyUsageCRLSign,
 	x509.KeyUsageEncipherOnly,
 	x509.KeyUsageDecipherOnly,
+}
+
+var signatureSchemeStrings = map[tls.SignatureScheme]string{
+	// Upper 8 bits are "hash" and lower 8 bits are "signature"
+	// Some values below, see RFC 5246, Section A.4.1, and also
+	// https://tools.ietf.org/html/draft-ietf-tls-tls13-18#section-4.2.3
+	// --
+	// Signatures:
+	// 0x0 anonymous
+	// 0x1 RSA
+	// 0x2 DSA
+	// 0x3 ECDSA
+	// --
+	// Hashes:
+	// 0x0 none
+	// 0x1 MD-5
+	// 0x2 SHA-1
+	// 0x3 SHA-224
+	// 0x4 SHA-256
+	// 0x5 SHA-384
+	// 0x6 SHA-512
+	// --
+	tls.PKCS1WithSHA1:          "RSA-PKCS1WithSHA1",
+	tls.PKCS1WithSHA256:        "RSA-PKCS1WithSHA256",
+	tls.PKCS1WithSHA384:        "RSA-PKCS1WithSHA384",
+	tls.PKCS1WithSHA512:        "RSA-PKCS1WithSHA512",
+	tls.PSSWithSHA256:          "RSA-PSSWithSHA256",
+	tls.PSSWithSHA384:          "RSA-PSSWithSHA384",
+	tls.PSSWithSHA512:          "RSA-PSSWithSHA512",
+	tls.ECDSAWithP256AndSHA256: "ECDSAWithP256AndSHA256",
+	tls.ECDSAWithP384AndSHA384: "ECDSAWithP384AndSHA384",
+	tls.ECDSAWithP521AndSHA512: "ECDSAWithP521AndSHA512",
+
+	// Not from stdlib
+	// Defined in TLS 1.3 draft
+	0x807: "ED25519",
+	0x808: "ED448",
+
+	// Not in stdlib: server sent {sha1,ecdsa}.
+	// This is sent (at least) by Go 1.8.1 servers in TLS 1.2 handshakes.
+	0x203: "ECDSAWithSHA1",
+
+	// Unused (?) but theorically possible combos (per RFC 5246)
+	0x101: "RSA-PKCS1WithMD5",
+	0x301: "RSA-PKCS1WithSHA224",
+	0x102: "DSAWithMD5",
+	0x202: "DSAWithSHA1",
+	0x302: "DSAWithSHA224",
+	0x402: "DSAWithSHA256",
+	0x502: "DSAWithSHA384",
+	0x602: "DSAWithSHA512",
 }
 
 var keyUsageStrings = map[x509.KeyUsage]string{

--- a/main.go
+++ b/main.go
@@ -109,12 +109,13 @@ func main() {
 			fmt.Fprintln(os.Stderr, "--identity can only be used with --start-tls")
 			os.Exit(1)
 		}
-		connState, err := starttls.GetConnectionState(*connectStartTLS, *connectName, *connectTo, *connectIdentity, *connectCert, *connectKey, *connectTimeout)
+		connState, cri, err := starttls.GetConnectionState(*connectStartTLS, *connectName, *connectTo, *connectIdentity, *connectCert, *connectKey, *connectTimeout)
 		if err != nil {
 			fmt.Fprintf(os.Stderr, "%s\n", strings.TrimSuffix(err.Error(), "\n"))
 			os.Exit(1)
 		}
 		result.TLSConnectionState = connState
+		result.CertificateRequestInfo = cri
 		for _, cert := range connState.PeerCertificates {
 			if *connectPem {
 				pem.Encode(os.Stdout, lib.EncodeX509ToPEM(cert, nil))
@@ -138,7 +139,10 @@ func main() {
 			blob, _ := json.Marshal(result)
 			fmt.Println(string(blob))
 		} else if !*connectPem {
-			fmt.Fprintf(stdout, "%s\n\n", lib.EncodeTLSToText(result.TLSConnectionState))
+			fmt.Fprintf(
+				stdout, "%s\n\n",
+				lib.EncodeTLSInfoToText(result.TLSConnectionState, result.CertificateRequestInfo))
+
 			for i, cert := range result.Certificates {
 				fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
 				fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert, terminalWidth, *verbose))


### PR DESCRIPTION
Example output:
```
** TLS Connection **
Version: TLS 1.2
Cipher Suite: ECDHE_RSA key exchange, AES_128_GCM_SHA256 cipher

Server has requested a client certificate:
Acceptable issuers:
	C=US, ST=CA, O=ghostunnel, OU=root
Supported Signature Schemes:
	RSA-PKCS1WithSHA256
	ECDSAWithP256AndSHA256
	RSA-PKCS1WithSHA384
	ECDSAWithP384AndSHA384
	RSA-PKCS1WithSHA1
	ECDSAWithSHA1

** CERTIFICATE 1 **
Valid: 2016-06-10 21:12 UTC to 2019-03-07 21:12 UTC
Subject: CN=server
Issuer: C=US, ST=CA, O=ghostunnel, OU=root
Alternate DNS Names:
	localhost
Alternate IP Addresses:
	127.0.0.1, ::1

Found 1 valid certificate chain(s):
[0] CN=server
	=> C=US, ST=CA, O=ghostunnel, OU=root [self-signed]
```

Note: this will only reliably work if you compile with Go 1.8.1, due to a bug in Go 1.8.0 where the GetClientCertificate callback isn't copied over when cloning a config. 