### PR TITLE
Better error handling in certigo dump command

### DIFF
--- a/pkcs7/pkcs7.go
+++ b/pkcs7/pkcs7.go
@@ -36,7 +36,7 @@ type SignedDataEnvelope struct {
 // Refer to RFC 2315, Section 9.1 for definition of this type.
 type SignedData struct {
 	Version          int
-	DigestAlgorithms []asn1.ObjectIdentifier `asn1:"set"`
+	DigestAlgorithms []asn1.RawValue `asn1:"set"`
 	ContentInfo      asn1.RawValue
 	Certificates     []asn1.RawValue `asn1:"tag:0,optional,set"`
 	RevocationLists  []asn1.RawValue `asn1:"tag:1,optional,set"`


### PR DESCRIPTION
Better error handling in certigo dump command.

Previous:
```
$ certigo dump < invalid-data
$
```

Updated:
```
$ certigo dump < invalid-data
error parsing block: asn1: structure error: sequence tag mismatch
warning: no certificates found in input
$
```