### PR TITLE
Default to using the "long" help format

### DIFF
--- a/main.go
+++ b/main.go
@@ -75,6 +75,8 @@ func main() {
 
 	// Alias starttls to start-tls
 	connect.Flag("starttls", "").Hidden().EnumVar(connectStartTLS, starttls.Protocols...)
+	// Use long help because many useful flags are under subcommands
+	app.UsageTemplate(kingpin.LongHelpTemplate)
 
 	stdout := colorable.NewColorableStdout()
 	result := simpleResult{}


### PR DESCRIPTION
Certigo doesn't have too many options, so the long help is a reasonble default.