### PR TITLE
Added --depth flag and CSR parsing

### DIFF
--- a/lib/display.go
+++ b/lib/display.go
@@ -56,7 +56,7 @@ Authority Key ID: {{.Issuer.KeyID | hexify}}
 {{- if .BasicConstraints}}
 Basic Constraints: CA:{{.BasicConstraints.IsCA}}{{if .BasicConstraints.MaxPathLen}}, pathlen:{{.BasicConstraints.MaxPathLen}}{{end}}{{end}}
 {{- if .NameConstraints}}
-Name Constraints{{if .NameConstraints.Critical}} (critical){{end}}: 
+Name Constraints{{if .NameConstraints.Critical}} (critical){{end}}:
 {{- if .NameConstraints.PermittedDNSDomains}}
 Permitted DNS domains:
 	{{wrapWith .Width "\n\t" (join ", " .NameConstraints.PermittedDNSDomains)}}

--- a/lib/display.go
+++ b/lib/display.go
@@ -156,6 +156,64 @@ Email Addresses:
 Warnings:{{range .Warnings}}
 	{{. | redify}}{{end}}{{end}}`
 
+var csrLayout = `
+{{- if .Version}}{{.Version}}
+{{end -}}
+Subject:
+	{{wrapWith .Width "\n\t" (.Subject.Name | printShortName)}}
+{{- if .AltDNSNames}}
+DNS Names:
+	{{wrapWith .Width "\n\t" (join ", " .AltDNSNames)}}{{end}}
+{{- if .AltIPAddresses}}
+	{{wrapWith .Width "\n\t" (join ", " .AltIPAdresses)}}{{end}}
+{{- if .URINames}}
+URI Names:
+	{{wrapWith .Width "\n\t" (join ", " .URINames)}}{{end}}
+{{- if .EmailAddresses}}
+Email Addresses:
+	{{wrapWith .Width "\n\t" (join ", " .EmailAddresses)}}{{end}}
+{{- if .Warnings}}
+Warnings:{{range .Warnings}}
+	{{. | redify}}{{end}}{{end}}`
+
+var verboseCSRLayout = `
+{{- define "PkixName" -}}
+{{- range .Names}}
+	{{ .Type | oidName }}: {{ .Value }}
+{{- end -}}
+{{end -}}
+
+{{- if .Subject.Name.SerialNumber}}
+Serial: {{.Subject.Name.SerialNumber}}{{- end}}
+Signature: {{.SignatureAlgorithm | highlightAlgorithm}}
+Subject Info:
+	{{- template "PkixName" .Subject.Name}}
+{{- if .AltDNSNames}}
+{{- range .Extensions}}
+	{{ .Id | oidName}}: {{.Value}}
+{{- end -}}
+DNS Names:
+	{{wrapWith .Width "\n\t" (join ", " .AltDNSNames)}}
+{{- end}}
+{{- if .AltIPAddresses}}
+IP Addresses:
+	{{wrapWith .Width "\n\t" (join ", " .AltIPAddresses)}}
+{{- end}}
+{{- if .URINames}}
+URI Names:
+	{{wrapWith .Width "\n\t" (join ", " .URINames)}}
+{{- end}}
+{{- if .EmailAddresses}}
+Email Addresses:
+	{{wrapWith .Width "\n\t" (join ", " .EmailAddresses)}}
+{{- end}}
+{{- if .Warnings}}
+Warnings:
+{{- range .Warnings}}
+	{{. | redify}}
+{{- end}}
+{{- end}}`
+
 type certWithName struct {
 	name string
 	file string
@@ -200,52 +258,92 @@ func EncodeX509ToObject(cert *x509.Certificate) interface{} {
 }
 
 // EncodeX509ToText encodes an X.509 certificate into human-readable text.
-func EncodeX509ToText(cert *x509.Certificate, terminalWidth int, verbose bool) []byte {
-	c := createSimpleCertificate("", cert)
-	c.Width = terminalWidth - 8 /* Need some margin for tab */
-
-	return displayCert(c, verbose)
+func EncodeX509ToText(obj interface{}, terminalWidth int, verbose bool) []byte {
+	switch obj.(type) {
+	case *x509.Certificate:
+		obj, ok := obj.(*x509.Certificate)
+		if ok {
+			c := createSimpleCertificate("", obj)
+			c.Width = terminalWidth - 8 /* Need some margin for tab */
+			return displayCert(c, verbose)
+		}
+	case *x509.CertificateRequest:
+		obj, ok := obj.(*x509.CertificateRequest)
+		if ok {
+			c := createSimpleCertificateRequest("", obj)
+			c.Width = terminalWidth - 8 /* Need some margin for tab */
+			return displayCert(c, verbose)
+		}
+	}
+	// should never happen
+	return nil
 }
 
 // displayCert takes in a parsed certificate object
 // (for jceks certs, blank otherwise), and prints out relevant
 // information. Start and end dates are colored based on whether or not
 // the certificate is expired, not expired, or close to expiring.
-func displayCert(cert simpleCertificate, verbose bool) []byte {
+func displayCert(obj interface{}, verbose bool) []byte {
 	// Use template functions from sprig, but add some extras
 	funcMap := sprig.TxtFuncMap()
-
-	extras := template.FuncMap{
-		"certStart":          certStart,
-		"certEnd":            certEnd,
-		"redify":             redify,
-		"highlightAlgorithm": highlightAlgorithm,
-		"hexify":             hexify,
-		"keyUsage":           keyUsage,
-		"extKeyUsage":        extKeyUsage,
-		"oidName":            oidName,
-		"oidShort":           oidShort,
-		"printShortName":     PrintShortName,
-		"printCommonName":    PrintCommonName,
-	}
-	for k, v := range extras {
-		funcMap[k] = v
-	}
-
-	t := template.New("Cert template").Funcs(funcMap)
+	var t *template.Template
 	var err error
-	if verbose {
-		t, err = t.Parse(verboseLayout)
-	} else {
-		t, err = t.Parse(layout)
+
+	switch obj.(type) {
+	case simpleCertificate:
+		extras := template.FuncMap{
+			"certStart":          certStart,
+			"certEnd":            certEnd,
+			"redify":             redify,
+			"highlightAlgorithm": highlightAlgorithm,
+			"hexify":             hexify,
+			"keyUsage":           keyUsage,
+			"extKeyUsage":        extKeyUsage,
+			"oidName":            oidName,
+			"oidShort":           oidShort,
+			"printShortName":     PrintShortName,
+			"printCommonName":    PrintCommonName,
+		}
+		for k, v := range extras {
+			funcMap[k] = v
+		}
+
+		t = template.New("Cert template").Funcs(funcMap)
+		if verbose {
+			t, err = t.Parse(verboseLayout)
+		} else {
+			t, err = t.Parse(layout)
+		}
+
+	case simpleCertificateRequest:
+		extras := template.FuncMap{
+			"redify":             redify,
+			"highlightAlgorithm": highlightAlgorithm,
+			"hexify":             hexify,
+			"oidName":            oidName,
+			"oidShort":           oidShort,
+			"printShortName":     PrintShortName,
+			"printCommonName":    PrintCommonName,
+		}
+		for k, v := range extras {
+			funcMap[k] = v
+		}
+
+		t = template.New("Cert Request template").Funcs(funcMap)
+		if verbose {
+			t, err = t.Parse(verboseCSRLayout)
+		} else {
+			t, err = t.Parse(csrLayout)
+		}
 	}
+
 	if err != nil {
 		// Should never happen
 		panic(err)
 	}
 	var buffer bytes.Buffer
 	w := bufio.NewWriter(&buffer)
-	err = t.Execute(w, cert)
+	err = t.Execute(w, obj)
 	if err != nil {
 		// Should never happen
 		panic(err)

--- a/lib/encoder.go
+++ b/lib/encoder.go
@@ -209,6 +209,25 @@ type simpleCertificate struct {
 	Width int `json:"-"`
 }
 
+type simpleCertificateRequest struct {
+	Version            int                             `json:"version,omitempty"`
+	SignatureAlgorithm simpleSigAlg                    `json:"signature_algorithm"`
+	PublicKeyAlgorithm string                          `json:"public_key_algorithm"`
+	Subject            simplePKIXName                  `json:"subject"`
+	Attributes         []pkix.AttributeTypeAndValueSET `json:"attributes,omitempty"`
+	Extensions         []pkix.Extension                `json:"extensions,omitempty"`
+	ExtraExtensions    []pkix.Extension                `json:"extra_extensions,omitempty"`
+	AltDNSNames        []string                        `json:"dns_names,omitempty"`
+	EmailAddresses     []string                        `json:"email_addresses,omitempty"`
+	AltIPAddresses     []net.IP                        `json:"ip_addresses,omitempty"`
+	URINames           []string                        `json:"uri_names,omitempty"`
+	Warnings           []string                        `json:"warnings,omitempty"`
+	PEM                string                          `json:"pem,omitempty"`
+
+	// Internal fields for text display. Set - to skip serialize.
+	Width int `json:"-"`
+}
+
 type simplePKIXName struct {
 	Name  pkix.Name
 	KeyID []byte
@@ -287,6 +306,33 @@ func createSimpleCertificate(name string, cert *x509.Certificate) simpleCertific
 	return out
 }
 
+func createSimpleCertificateRequest(name string, csr *x509.CertificateRequest) simpleCertificateRequest {
+	out := simpleCertificateRequest{
+		Version:            csr.Version,
+		SignatureAlgorithm: simpleSigAlg(csr.SignatureAlgorithm),
+		PublicKeyAlgorithm: csr.PublicKeyAlgorithm.String(),
+		Subject: simplePKIXName{
+			Name:  csr.Subject,
+			KeyID: []byte(csr.Subject.SerialNumber),
+		},
+		Attributes:      csr.Attributes,
+		Extensions:      csr.Extensions,
+		ExtraExtensions: csr.ExtraExtensions,
+		AltDNSNames:     csr.DNSNames,
+		EmailAddresses:  csr.EmailAddresses,
+		AltIPAddresses:  csr.IPAddresses,
+		PEM:             string(pem.EncodeToMemory(EncodeX509CSRToPEM(csr, nil))),
+	}
+
+	uriNames, err := spiffe.GetURINamesFromPEM(out.PEM)
+	if err == nil {
+		out.URINames = uriNames
+	}
+
+	out.Warnings = csrWarnings(csr, uriNames)
+	return out
+}
+
 func (p simplePKIXName) MarshalJSON() ([]byte, error) {
 	out := map[string]interface{}{}
 
@@ -300,6 +346,10 @@ func (p simplePKIXName) MarshalJSON() ([]byte, error) {
 		} else {
 			out[oid.Slug] = rdn.Value
 		}
+	}
+
+	if len(p.Name.SerialNumber) > 0 {
+		out["serial_number"] = p.Name.SerialNumber
 	}
 
 	if len(p.KeyID) > 0 {
@@ -412,9 +462,49 @@ func certWarnings(cert *x509.Certificate, uriNames []string) (warnings []string)
 	return
 }
 
+func csrWarnings(csr *x509.CertificateRequest, uriNames []string) (warnings []string) {
+	if csr.CheckSignature() != nil {
+		warnings = append(warnings, "Signature on this appears to be invalid")
+	}
+
+	if csr.Version < 2 {
+		warnings = append(warnings, fmt.Sprintf("Certificate Request is not in X509v3 format (version is %d)", csr.Version+1))
+	}
+
+	if len(csr.DNSNames) == 0 && len(csr.IPAddresses) == 0 && len(uriNames) == 0 {
+		warnings = append(warnings, fmt.Sprintf("Certificate Request doesn't have any valid DNS/URI names or IP addresses set"))
+	}
+
+	warnings = append(warnings, algWarnings(csr)...)
+
+	return
+}
+
 // algWarnings checks key sizes, signature algorithms.
-func algWarnings(cert *x509.Certificate) (warnings []string) {
-	alg, size := decodeKey(cert.PublicKey)
+func algWarnings(obj interface{}) (warnings []string) {
+	var alg string
+	var size int
+	var signatureAlg x509.SignatureAlgorithm
+	var key *rsa.PublicKey
+	switch obj.(type) {
+	case *x509.Certificate:
+		cert, _ := obj.(*x509.Certificate)
+		alg, size = decodeKey(cert.PublicKey)
+		signatureAlg = cert.SignatureAlgorithm
+
+		if alg == "RSA" {
+			key = cert.PublicKey.(*rsa.PublicKey)
+		}
+
+	case *x509.CertificateRequest:
+		csr, _ := obj.(*x509.CertificateRequest)
+		alg, size = decodeKey(csr.PublicKey)
+		signatureAlg = csr.SignatureAlgorithm
+
+		if alg == "RSA" {
+			key = csr.PublicKey.(*rsa.PublicKey)
+		}
+	}
 	if (alg == "RSA" || alg == "DSA") && size < 2048 {
 		warnings = append(warnings, fmt.Sprintf("Size of %s key should be at least 2048 bits", alg))
 	}
@@ -423,13 +513,12 @@ func algWarnings(cert *x509.Certificate) (warnings []string) {
 	}
 
 	for _, alg := range badSignatureAlgorithms {
-		if cert.SignatureAlgorithm == alg {
+		if signatureAlg == alg {
 			warnings = append(warnings, fmt.Sprintf("Signed with %s, which is an outdated signature algorithm", algString(alg)))
 		}
 	}
 
 	if alg == "RSA" {
-		key := cert.PublicKey.(*rsa.PublicKey)
 		if key.E < 3 {
 			warnings = append(warnings, "Public key exponent in RSA key is less than 3")
 		}

--- a/lib/oids.go
+++ b/lib/oids.go
@@ -15,21 +15,22 @@ func describeOid(oid asn1.ObjectIdentifier) OidDescription {
 	raw := oid.String()
 	// Multiple should be true for any types that are []string in x509.pkix.Name. When in doubt, set it to true.
 	names := map[string]OidDescription{
-		"2.5.4.3":                   {"CommonName", "CN", "common_name", false},
-		"2.5.4.5":                   {"EV Incorporation Registration Number", "", "ev_registration_number", false},
-		"2.5.4.6":                   {"Country", "C", "country", true},
-		"2.5.4.7":                   {"Locality", "L", "locality", true},
-		"2.5.4.8":                   {"Province", "ST", "province", true},
-		"2.5.4.9":                   {"Street", "", "street", true},
-		"2.5.4.10":                  {"Organization", "O", "organization", true},
-		"2.5.4.11":                  {"Organizational Unit", "OU", "organizational_unit", true},
-		"2.5.4.15":                  {"Business Category", "", "business_category", true},
-		"2.5.4.17":                  {"Postal Code", "", "postalcode", true},
-		"1.2.840.113549.1.9.1":      {"Email Address", "", "email_address", true},
-		"1.3.6.1.4.1.311.60.2.1.1":  {"EV Incorporation Locality", "", "ev_locality", true},
-		"1.3.6.1.4.1.311.60.2.1.2":  {"EV Incorporation Province", "", "ev_province", true},
-		"1.3.6.1.4.1.311.60.2.1.3":  {"EV Incorporation Country", "", "ev_country", true},
-		"0.9.2342.19200300.100.1.1": {"User ID", "UID", "user_id", true},
+		"2.5.4.3":                    {"CommonName", "CN", "common_name", false},
+		"2.5.4.5":                    {"EV Incorporation Registration Number", "", "ev_registration_number", false},
+		"2.5.4.6":                    {"Country", "C", "country", true},
+		"2.5.4.7":                    {"Locality", "L", "locality", true},
+		"2.5.4.8":                    {"Province", "ST", "province", true},
+		"2.5.4.9":                    {"Street", "", "street", true},
+		"2.5.4.10":                   {"Organization", "O", "organization", true},
+		"2.5.4.11":                   {"Organizational Unit", "OU", "organizational_unit", true},
+		"2.5.4.15":                   {"Business Category", "", "business_category", true},
+		"2.5.4.17":                   {"Postal Code", "", "postalcode", true},
+		"1.2.840.113549.1.9.1":       {"Email Address", "", "email_address", true},
+		"1.3.6.1.4.1.311.60.2.1.1":   {"EV Incorporation Locality", "", "ev_locality", true},
+		"1.3.6.1.4.1.311.60.2.1.2":   {"EV Incorporation Province", "", "ev_province", true},
+		"1.3.6.1.4.1.311.60.2.1.3":   {"EV Incorporation Country", "", "ev_c`ountry", true},
+		"0.9.2342.19200300.100.1.1":  {"User ID", "UID", "user_id", true},
+		"0.9.2342.19200300.100.1.25": {"DomainComponent", "DC", "dc", true},
 	}
 	if description, ok := names[raw]; ok {
 		return description

--- a/lib/tls.go
+++ b/lib/tls.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"crypto/tls"
+	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/asn1"
 	"fmt"
@@ -126,6 +127,11 @@ func EncodeCRIToObject(cri *tls.CertificateRequestInfo) (interface{}, error) {
 		out.SignatureSchemes = append(out.SignatureSchemes, desc)
 	}
 	return out, nil
+}
+
+// EncodeCSRToObject returns a JSON-marshallable representation of a Certificate Request object
+func EncodeCSRToObject(csr *x509.CertificateRequest) interface{} {
+	return createSimpleCertificateRequest("", csr)
 }
 
 // Just a map lookup with a default

--- a/main.go
+++ b/main.go
@@ -42,6 +42,7 @@ var (
 	dumpPassword = dump.Flag("password", "Password for PKCS12/JCEKS key stores (reads from TTY if missing).").Short('p').String()
 	dumpPem      = dump.Flag("pem", "Write output as PEM blocks instead of human-readable format.").Short('m').Bool()
 	dumpJSON     = dump.Flag("json", "Write output as machine-readable JSON format.").Short('j').Bool()
+	dumpDepth    = dump.Flag("depth", "Certificate information upto a certain depth.").Short('d').Default("0").Int()
 
 	connect         = app.Command("connect", "Connect to a server and print its certificate(s).")
 	connectTo       = connect.Arg("server[:port]", "Hostname or IP to connect to, with optional port.").String()
@@ -55,6 +56,7 @@ var (
 	connectTimeout  = connect.Flag("timeout", "Timeout for connecting to remote server (can be '5m', '1s', etc).").Default("5s").Duration()
 	connectPem      = connect.Flag("pem", "Write output as PEM blocks instead of human-readable format.").Short('m').Bool()
 	connectJSON     = connect.Flag("json", "Write output as machine-readable JSON format.").Short('j').Bool()
+	connectDepth    = connect.Flag("depth", "Certificate information upto a certain depth.").Short('d').Default("0").Int()
 
 	verify         = app.Command("verify", "Verify a certificate chain from file/stdin against a name.")
 	verifyFile     = verify.Arg("file", "Certificate file to dump (or stdin if not specified).").ExistingFile()
@@ -102,11 +104,21 @@ func main() {
 				}
 			})
 
+			// Calculate the depth of certificate that needs to be processed
+			chainLength := len(result.Certificates)
+			idx := chainLength
+			if chainLength > *dumpDepth && *dumpDepth > 0 {
+				idx = *dumpDepth
+			}
+
 			if *dumpJSON {
+				// Adjust the length of the result.Certificates length
+				result.Certificates = result.Certificates[:idx]
 				blob, _ := json.Marshal(result)
 				fmt.Println(string(blob))
 			} else {
-				for i, cert := range result.Certificates {
+
+				for i, cert := range result.Certificates[:idx] {
 					fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
 					fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert, terminalWidth, *verbose))
 				}
@@ -133,7 +145,14 @@ func main() {
 		}
 		result.TLSConnectionState = connState
 		result.CertificateRequestInfo = cri
-		for _, cert := range connState.PeerCertificates {
+
+		chainLength := len(connState.PeerCertificates)
+		idx := chainLength
+		if chainLength > *connectDepth && *connectDepth > 0 {
+			idx = *connectDepth
+		}
+
+		for _, cert := range connState.PeerCertificates[:idx] {
 			if *connectPem {
 				pem.Encode(os.Stdout, lib.EncodeX509ToPEM(cert, nil))
 			} else {
@@ -151,6 +170,9 @@ func main() {
 			verifyResult := verifyChain(connState.PeerCertificates, hostname, *connectCaPath)
 			result.VerifyResult = &verifyResult
 		}
+
+		// Adjust the length of result.Certificates
+		result.Certificates = result.Certificates[:idx]
 
 		if *connectJSON {
 			blob, _ := json.Marshal(result)

--- a/verify.go
+++ b/verify.go
@@ -74,20 +74,24 @@ type simpleVerification struct {
 }
 
 type simpleResult struct {
-	Certificates           []*x509.Certificate `json:"certificates"`
-	VerifyResult           *simpleVerification `json:"verify_result,omitempty"`
+	Certificates           []*x509.Certificate        `json:"certificates"`
+	CertificateRequests    []*x509.CertificateRequest `json:"certificate_requests"`
+	VerifyResult           *simpleVerification        `json:"verify_result,omitempty"`
 	TLSConnectionState     *tls.ConnectionState
 	CertificateRequestInfo *tls.CertificateRequestInfo
 }
 
 func (s simpleResult) MarshalJSON() ([]byte, error) {
-	certs := make([]interface{}, len(s.Certificates))
-	for i, c := range s.Certificates {
-		certs[i] = lib.EncodeX509ToObject(c)
-	}
-
 	out := map[string]interface{}{}
-	out["certificates"] = certs
+
+	if s.Certificates != nil {
+		certs := make([]interface{}, len(s.Certificates))
+		for i, c := range s.Certificates {
+			certs[i] = lib.EncodeX509ToObject(c)
+		}
+
+		out["certificates"] = certs
+	}
 	if s.VerifyResult != nil {
 		out["verify_result"] = s.VerifyResult
 	}
@@ -100,6 +104,13 @@ func (s simpleResult) MarshalJSON() ([]byte, error) {
 			return nil, err
 		}
 		out["certificate_request_info"] = encoded
+	}
+	if s.CertificateRequests != nil {
+		csrs := make([]interface{}, len(s.CertificateRequests))
+		for i, c := range s.CertificateRequests {
+			csrs[i] = lib.EncodeCSRToObject(c)
+		}
+		out["certificate_requests"] = csrs
 	}
 	return json.Marshal(out)
 }


### PR DESCRIPTION
* Added a flag `--depth` in `dump` and `connect` that lets the tool display only the first cert which would be the leaf cert for cleaner output in basic and `--json` flag. It would not work in `--pem` though.

* Added CSR parsing capabilities with `--csr` flag in `dump`