### PR TITLE
Update README and CONTRIBUTING

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,17 +6,16 @@ go:
   - '1.11.x'
 
 install:
-  - go get github.com/Masterminds/glide
   - pip install cram --user
 
 before_script:
-  - go vet -v `glide nv`
+  - go vet -v ./...
 
 script:
   - GOOS=linux GOARCH=amd64 go build -o certigo-linux-amd64
   - GOOS=darwin GOARCH=amd64 go build -o certigo-darwin-amd64
   - GOOS=windows GOARCH=amd64 go build -o certigo-windows-amd64.exe
-  - go test -v `glide nv`
+  - go test -v ./...
   - ln -s certigo-linux-amd64 certigo
   - PATH=$PWD:$PATH cram -v tests/*.t
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,16 @@
 Contributing
 ============
 
-If you would like to contribute code to Certigo you can do so through GitHub by
-forking the repository and sending a pull request.
+We appreciate your desire to contribute code to this repo. You may do so
+through GitHub by forking the repository and sending a pull request.
 
 When submitting code, please make every effort to follow existing conventions
 and style in order to keep the code as readable as possible. Please also make
-sure your code compiles and passes tests.
+sure all tests pass by running `go test ./...`, and format your code with `go fmt`.
+We also recommend using `golint`.
 
 Before your code can be accepted into the project you must also sign the
-[Individual Contributor License Agreement (CLA)][1].
+Individual Contributor License Agreement.  We use [cla-assistant.io][1] and you
+will be prompted to sign once a pull request is opened.
 
-
- [1]: https://spreadsheets.google.com/spreadsheet/viewform?formkey=dDViT2xzUHAwRkI3X3k5Z0lQM091OGc6MQ&ndplr=1
+[1]: https://cla-assistant.io/

--- a/README.md
+++ b/README.md
@@ -9,9 +9,9 @@ Certigo is a utility to examine and validate certificates to help with debugging
 
 ### Features
 
-**Supports all common file formats**: Certigo can read and dump certificates in various formats. It can automatically detect and read from X.509 (DER/PEM), JCEKS, PKCS7 and PKCS12 files. Certificates can be dumped to a human-readable format, a set of PEM blocks, or a JSON object for use in scripting. 
+**Supports all common file formats**: Certigo can read and dump certificates in various formats. It can automatically detect and read from X.509 (DER/PEM), JCEKS, PKCS7 and PKCS12 files. Certificates can be dumped to a human-readable format, a set of PEM blocks, or a JSON object for use in scripting.
 
-**Validation and linting**: Not sure if your generated certificate is valid? Certigo can connect to remote servers to display and validate their certificate chains. It can also point out common errors on certififcates, such as using an older X.509 format, signatures with outdated hashes, or keys that are too small. 
+**Validation and linting**: Not sure if your generated certificate is valid? Certigo can connect to remote servers to display and validate their certificate chains. It can also point out common errors on certififcates, such as using an older X.509 format, signatures with outdated hashes, or keys that are too small.
 
 **Supports STARTTLS Protocols**: Trying to debug SSL/TLS connections on a database or mail server? Certigo supports establishing connections via StartTLS protocols for MySQL, PostgreSQL, SMTP, LDAP, and FTP, making it possible to debug connection issues or scan for expired certificates more easily.
 
@@ -31,13 +31,13 @@ Note that certigo requires Go 1.11 or later to build.
 
 ### Develop
 
-We use [glide][1] for managing vendored dependencies. If you would like to contribute, see the [CONTRIBUTING.md](CONTRIBUTING.md) file for extra information.  
+We use [Go modules][1] for managing vendored dependencies. If you would like to contribute, see the [CONTRIBUTING.md](CONTRIBUTING.md) file for extra information.
 
-[1]: https://glide.sh
+[1]: https://github.com/golang/go/wiki/Modules
 
 ### Usage
 
-Certigo has commands to dump certificates and keystores from a file, to connect and fetch certificates from a remote server, and to verify the validity of certificates in a file. All commands can produce JSON output with the `--json` flag which can be used for scripting. See below for a full list of options. 
+Certigo has commands to dump certificates and keystores from a file, to connect and fetch certificates from a remote server, and to verify the validity of certificates in a file. All commands can produce JSON output with the `--json` flag which can be used for scripting. See below for a full list of options.
 
 ```
 usage: certigo [<flags>] <command> [<args> ...]


### PR DESCRIPTION
- readme: removed reference to Glide and mentioned Go modules
- contributing: language tweaks & updated link to CLA
- CI: remove glide dependency, since we don't need it and Go 1.11
  ignores vendored dirs when using `./...` argument to go tools.