### PR TITLE
Add --leaf flag to read only the leaf cert

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,7 +42,7 @@ Certigo has commands to dump certificates and keystores from a file, to connect 
 ```
 usage: certigo [<flags>] <command> [<args> ...]
 
-A command line certificate examination utility.
+A command-line utility to examine and validate certificates to help with debugging SSL/TLS issues.
 
 Flags:
       --help     Show context-sensitive help (also try --help-long and --help-man).
@@ -55,24 +55,29 @@ Commands:
 
 
   dump [<flags>] [<file>...]
-    Display information about a certificate from a file/stdin.
+    Display information about a certificate from a file or stdin.
 
     -f, --format=FORMAT      Format of given input (PEM, DER, JCEKS, PKCS12; heuristic if missing).
     -p, --password=PASSWORD  Password for PKCS12/JCEKS key stores (reads from TTY if missing).
     -m, --pem                Write output as PEM blocks instead of human-readable format.
     -j, --json               Write output as machine-readable JSON format.
+    -l, --leaf               Certificate chain information only for the leaf cert.
 
-  connect [<flags>] [<server:port>]
+  connect [<flags>] [<server[:port]>]
     Connect to a server and print its certificate(s).
 
     -n, --name=NAME           Override the server name used for Server Name Indication (SNI).
         --ca=CA               Path to CA bundle (system default if unspecified).
         --cert=CERT           Client certificate chain for connecting to server (PEM).
         --key=KEY             Private key for client certificate, if not in same file (PEM).
-    -t, --start-tls=PROTOCOL  Enable StartTLS protocol ('ldap', 'mysql', 'postgres', 'smtp' or 'ftp').
+    -t, --start-tls=PROTOCOL  Enable StartTLS protocol; one of: [mysql postgres psql smtp ldap ftp imap].
+        --identity="certigo"  With --start-tls, sets the DB user or SMTP EHLO name
+        --proxy=PROXY         Optional URI for HTTP(s) CONNECT proxy to dial connections with
         --timeout=5s          Timeout for connecting to remote server (can be '5m', '1s', etc).
     -m, --pem                 Write output as PEM blocks instead of human-readable format.
     -j, --json                Write output as machine-readable JSON format.
+        --verify              Verify certificate chain.
+    -l, --leaf                Certificate chain information only for the leaf cert.
 
   verify --name=NAME [<flags>] [<file>]
     Verify a certificate chain from file/stdin against a name.

--- a/lib/display.go
+++ b/lib/display.go
@@ -56,7 +56,7 @@ Authority Key ID: {{.Issuer.KeyID | hexify}}
 {{- if .BasicConstraints}}
 Basic Constraints: CA:{{.BasicConstraints.IsCA}}{{if .BasicConstraints.MaxPathLen}}, pathlen:{{.BasicConstraints.MaxPathLen}}{{end}}{{end}}
 {{- if .NameConstraints}}
-Name Constraints{{if .NameConstraints.Critical}} (critical){{end}}: 
+Name Constraints{{if .NameConstraints.Critical}} (critical){{end}}:
 {{- if .NameConstraints.PermittedDNSDomains}}
 Permitted DNS domains:
 	{{wrapWith .Width "\n\t" (join ", " .NameConstraints.PermittedDNSDomains)}}

--- a/main.go
+++ b/main.go
@@ -41,6 +41,7 @@ var (
 	dumpPassword = dump.Flag("password", "Password for PKCS12/JCEKS key stores (reads from TTY if missing).").Short('p').String()
 	dumpPem      = dump.Flag("pem", "Write output as PEM blocks instead of human-readable format.").Short('m').Bool()
 	dumpJSON     = dump.Flag("json", "Write output as machine-readable JSON format.").Short('j').Bool()
+	dumpLeaf     = dump.Flag("leaf", "Certificate chain information only for the leaf cert.").Short('l').Default("false").Bool()
 
 	connect         = app.Command("connect", "Connect to a server and print its certificate(s).")
 	connectTo       = connect.Arg("server[:port]", "Hostname or IP to connect to, with optional port.").String()
@@ -55,6 +56,7 @@ var (
 	connectPem      = connect.Flag("pem", "Write output as PEM blocks instead of human-readable format.").Short('m').Bool()
 	connectJSON     = connect.Flag("json", "Write output as machine-readable JSON format.").Short('j').Bool()
 	connectVerify   = connect.Flag("verify", "Verify certificate chain.").Bool()
+	connectLeaf     = connect.Flag("leaf", "Certificate chain information only for the leaf cert.").Short('l').Default("false").Bool()
 
 	verify         = app.Command("verify", "Verify a certificate chain from file/stdin against a name.")
 	verifyFile     = verify.Arg("file", "Certificate file to dump (or stdin if not specified).").ExistingFile()
@@ -104,11 +106,21 @@ func main() {
 				}
 			})
 
+			// Calculate the depth of certificate from the leaf up that needs to be processed
+			chainLength := len(result.Certificates)
+			idx := chainLength
+			if chainLength > 1 && *dumpLeaf {
+				idx = 1
+			}
+
 			if *dumpJSON {
+				// Adjust the length of the result.Certificates length
+				result.Certificates = result.Certificates[:idx]
 				blob, _ := json.Marshal(result)
 				fmt.Println(string(blob))
 			} else {
-				for i, cert := range result.Certificates {
+
+				for i, cert := range result.Certificates[:idx] {
 					fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
 					fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert, terminalWidth, *verbose))
 				}
@@ -135,7 +147,14 @@ func main() {
 		}
 		result.TLSConnectionState = connState
 		result.CertificateRequestInfo = cri
-		for _, cert := range connState.PeerCertificates {
+
+		chainLength := len(connState.PeerCertificates)
+		idx := chainLength
+		if chainLength > 0 && *connectLeaf {
+			idx = 1
+		}
+
+		for _, cert := range connState.PeerCertificates[:idx] {
 			if *connectPem {
 				pem.Encode(os.Stdout, lib.EncodeX509ToPEM(cert, nil))
 			} else {
@@ -151,6 +170,9 @@ func main() {
 		}
 		verifyResult := lib.VerifyChain(connState.PeerCertificates, connState.OCSPResponse, hostname, *connectCaPath)
 		result.VerifyResult = &verifyResult
+
+		// Adjust the length of result.Certificates
+		result.Certificates = result.Certificates[:idx]
 
 		if *connectJSON {
 			blob, _ := json.Marshal(result)


### PR DESCRIPTION
Added another flag --leaf to connect and dump to limit the number
of certificates to be printed in --json or --pem flags to make is
easier to ignore if only the leaft certificate is required.

Old vs New Commands:
* dump just the leaf cert
old : certigo dump cert_chain.pem --json | jq '.certificates[0]'
new : certigo dump cert_chain.pem --json --leaf | jq
Similar with other flags eg --verbose or short
description

* connect to get just the leaf cert
old : certigo connect hostname --json | jq '.certificates[0]'
new : certigo connect hostname --json --leaf | jq

old : certigo connect hostname --json --start-tls ldap | jq
'.certificates[0]'
new : certigo connect hostname --json --start-tls ldap --leaf | jq

This option is not implemented in verify and can be added if there is a
good response to this commit.