### PR TITLE
Add DomainComponent from RFC 2247

### DIFF
--- a/lib/oids.go
+++ b/lib/oids.go
@@ -15,21 +15,22 @@ func describeOid(oid asn1.ObjectIdentifier) OidDescription {
 	raw := oid.String()
 	// Multiple should be true for any types that are []string in x509.pkix.Name. When in doubt, set it to true.
 	names := map[string]OidDescription{
-		"2.5.4.3":                   {"CommonName", "CN", "common_name", false},
-		"2.5.4.5":                   {"EV Incorporation Registration Number", "", "ev_registration_number", false},
-		"2.5.4.6":                   {"Country", "C", "country", true},
-		"2.5.4.7":                   {"Locality", "L", "locality", true},
-		"2.5.4.8":                   {"Province", "ST", "province", true},
-		"2.5.4.9":                   {"Street", "", "street", true},
-		"2.5.4.10":                  {"Organization", "O", "organization", true},
-		"2.5.4.11":                  {"Organizational Unit", "OU", "organizational_unit", true},
-		"2.5.4.15":                  {"Business Category", "", "business_category", true},
-		"2.5.4.17":                  {"Postal Code", "", "postalcode", true},
-		"1.2.840.113549.1.9.1":      {"Email Address", "", "email_address", true},
-		"1.3.6.1.4.1.311.60.2.1.1":  {"EV Incorporation Locality", "", "ev_locality", true},
-		"1.3.6.1.4.1.311.60.2.1.2":  {"EV Incorporation Province", "", "ev_province", true},
-		"1.3.6.1.4.1.311.60.2.1.3":  {"EV Incorporation Country", "", "ev_country", true},
-		"0.9.2342.19200300.100.1.1": {"User ID", "UID", "user_id", true},
+		"2.5.4.3":                    {"CommonName", "CN", "common_name", false},
+		"2.5.4.5":                    {"EV Incorporation Registration Number", "", "ev_registration_number", false},
+		"2.5.4.6":                    {"Country", "C", "country", true},
+		"2.5.4.7":                    {"Locality", "L", "locality", true},
+		"2.5.4.8":                    {"Province", "ST", "province", true},
+		"2.5.4.9":                    {"Street", "", "street", true},
+		"2.5.4.10":                   {"Organization", "O", "organization", true},
+		"2.5.4.11":                   {"Organizational Unit", "OU", "organizational_unit", true},
+		"2.5.4.15":                   {"Business Category", "", "business_category", true},
+		"2.5.4.17":                   {"Postal Code", "", "postalcode", true},
+		"1.2.840.113549.1.9.1":       {"Email Address", "", "email_address", true},
+		"1.3.6.1.4.1.311.60.2.1.1":   {"EV Incorporation Locality", "", "ev_locality", true},
+		"1.3.6.1.4.1.311.60.2.1.2":   {"EV Incorporation Province", "", "ev_province", true},
+		"1.3.6.1.4.1.311.60.2.1.3":   {"EV Incorporation Country", "", "ev_country", true},
+		"0.9.2342.19200300.100.1.1":  {"User ID", "UID", "user_id", true},
+		"0.9.2342.19200300.100.1.25": {"Domain Component", "DC", "domain_component", true},
 	}
 	if description, ok := names[raw]; ok {
 		return description


### PR DESCRIPTION
I found TP-LINK routers submit some kind of logging to
n-devs.tplinkcloud.com:50443 and the CA that signed the certificate
for that domain had DCs in its subject

With this change we now get:
Issuer:
	DC=cn, DC=com, DC=tp-link, CN=TP-LINK CA P1