### PR TITLE
[trivial] added --json flag to readme examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -247,8 +247,8 @@ for SERVER in $(cat servers); do
 done
 
 # Find (redundant) self-signed certificates in intermediate chain on remote host
-certigo connect $SERVER:$PORT | jq -e '.certificates[1:][] | select(.is_self_signed) | .subject.common_name'
+certigo connect --json $SERVER:$PORT | jq -e '.certificates[1:][] | select(.is_self_signed) | .subject.common_name'
 
 # Test if server is requesting that clients send certificates for authentication
-certigo connect $SERVER:$PORT | jq -e '.certificate_request_info != null'
+certigo connect --json $SERVER:$PORT | jq -e '.certificate_request_info != null'
 ```


### PR DESCRIPTION
Without the flag the human readable details would be output which fail once piped into `jq`.