### PR TITLE
Better error message for missing intermediates

### DIFF
--- a/lib/verify.go
+++ b/lib/verify.go
@@ -22,6 +22,8 @@ import (
 	"encoding/pem"
 	"fmt"
 	"io"
+	"io/ioutil"
+	"net/http"
 	"os"
 	"time"
 
@@ -109,6 +111,30 @@ func caBundle(caPath string) *x509.CertPool {
 	return bundle
 }
 
+func fetchAIA(cert *x509.Certificate) *x509.Certificate {
+	for _, url := range cert.IssuingCertificateURL {
+		resp, err := http.Get(url)
+		if err != nil {
+			continue
+		}
+
+		defer resp.Body.Close()
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			continue
+		}
+
+		intermediate, err := x509.ParseCertificate(body)
+		if err != nil {
+			continue
+		}
+
+		return intermediate
+	}
+
+	return nil
+}
+
 func VerifyChain(certs []*x509.Certificate, ocspStaple []byte, dnsName, caPath string) SimpleVerification {
 	result := SimpleVerification{
 		Chains:         [][]simpleVerifyCert{},
@@ -129,6 +155,20 @@ func VerifyChain(certs []*x509.Certificate, ocspStaple []byte, dnsName, caPath s
 	chains, err := certs[0].Verify(opts)
 	if err != nil {
 		result.Error = fmt.Sprintf("%s", err)
+
+		if len(intermediates.Subjects()) == 0 {
+			// No intermediates found, maybe broken chain. Let's try AIA fetching?
+			intermediate := fetchAIA(certs[0])
+			if intermediate != nil {
+				intermediates.AddCert(intermediate)
+				_, err := certs[0].Verify(opts)
+				if err == nil {
+					// Would work with proper intermediates.
+					result.Error = "server is not sending required intermediate certificate(s)"
+				}
+			}
+		}
+
 		return result
 	}
 


### PR DESCRIPTION
If verification fails, retries using intermediate retrieved via AIA fetching and updates error message to make it clearer what the misconfiguration is.

Used to print:
![Screen Shot 2019-04-04 at 15 25 25](https://user-images.githubusercontent.com/639883/55592690-179ed080-56ee-11e9-8290-29484e38f34f.png)

But now shows:
![Screen Shot 2019-04-04 at 15 25 05](https://user-images.githubusercontent.com/639883/55592694-1ec5de80-56ee-11e9-8592-6a88cf11298b.png)

This is best-effort.