### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ On macOS you can also use homebrew to install:
 
     brew install certigo
 
-Note that certigo requires Go 1.11 or later to build.
+Note that certigo requires Go 1.12 or later to build.
 
 ### Develop
 


### PR DESCRIPTION
As of #185, certigo requires Go 1.12 to build.

Related to #186

