### PR TITLE
print input format guessed by certigo

### DIFF
--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -42,6 +42,7 @@ t/DtcM/GpAhBbLP9Tk7kPB41v5fRIxVDo50Iz/qvkr37pQ4RsejSFg==
 `
 
 const expectedVerbose string = `** CERTIFICATE 1 **
+Input Format: PEM
 Serial: 4096
 Valid: 2017-07-19 16:50 UTC to 2017-07-29 16:50 UTC
 Signature: SHA256-RSA

--- a/lib/certs.go
+++ b/lib/certs.go
@@ -195,7 +195,8 @@ func readCertsFromStream(reader io.Reader, filename string, format string, passw
 		headers[fileHeader] = filename
 	}
 
-	switch strings.TrimSpace(format) {
+	format = strings.TrimSpace(format)
+	switch format {
 	case "PEM":
 		scanner := pemScanner(reader)
 		for scanner.Scan() {

--- a/lib/verify.go
+++ b/lib/verify.go
@@ -47,6 +47,7 @@ type SimpleVerification struct {
 
 type SimpleResult struct {
 	Certificates           []*x509.Certificate `json:"certificates"`
+	Formats                []string
 	VerifyResult           *SimpleVerification `json:"verify_result,omitempty"`
 	TLSConnectionState     *tls.ConnectionState
 	CertificateRequestInfo *tls.CertificateRequestInfo
@@ -94,7 +95,7 @@ func caBundle(caPath string) (*x509.CertPool, error) {
 			// TODO: The JDK trust store ships with this password.
 			return "changeit"
 		},
-		func(cert *x509.Certificate, err error) error {
+		func(cert *x509.Certificate, format string, err error) error {
 			if err != nil {
 				return fmt.Errorf("error parsing CA bundle: %s\n", err)
 			} else {

--- a/tests/dump-cert-chain-to-text.t
+++ b/tests/dump-cert-chain-to-text.t
@@ -109,6 +109,7 @@ Dump a live cert chain (squareup-chain.crt)
 
   $ certigo --verbose dump squareup-chain.crt
   ** CERTIFICATE 1 **
+  Input Format: PEM
   Serial: 260680855742043049380997676879525498489
   Valid: 2016-07-15 20:15 UTC to 2017-07-31 20:45 UTC
   Signature: SHA256-RSA
@@ -148,6 +149,7 @@ Dump a live cert chain (squareup-chain.crt)
   \tgosq.co, www.gosq.co (esc)
   
   ** CERTIFICATE 2 **
+  Input Format: PEM
   Serial: 30215777750102225331854468774
   Valid: 2014-12-15 15:25 UTC to 2030-10-15 15:55 UTC
   Signature: SHA256-RSA
@@ -176,6 +178,7 @@ Dump a live cert chain (squareup-chain.crt)
   \tServer Auth (esc)
   
   ** CERTIFICATE 3 **
+  Input Format: PEM
   Serial: 1372799044
   Valid: 2014-09-22 17:14 UTC to 2024-09-23 01:31 UTC
   Signature: SHA256-RSA

--- a/tests/dump-leaf-to-not-verbose.t
+++ b/tests/dump-leaf-to-not-verbose.t
@@ -28,6 +28,7 @@ Dump an example certificate (example-leaf.crt)
 
   $ certigo dump example-leaf.crt
   ** CERTIFICATE 1 **
+  Input Format: PEM
   Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
   Subject:
   \tC=US, ST=CA, O=certigo, OU=example, CN=example-leaf (esc)

--- a/tests/dump-leaf-to-text.t
+++ b/tests/dump-leaf-to-text.t
@@ -28,6 +28,7 @@ Dump an example certificate (example-leaf.crt)
 
   $ certigo --verbose dump example-leaf.crt
   ** CERTIFICATE 1 **
+  Input Format: PEM
   Serial: 15384458167827828543
   Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
   Signature: SHA256-RSA

--- a/tests/dump-name-constraints-to-text.t
+++ b/tests/dump-name-constraints-to-text.t
@@ -55,6 +55,7 @@ Dump an example certificate with name constraints (example-name-constraints.crt)
 
   $ certigo --verbose dump example-name-constraints.crt
   ** CERTIFICATE 1 **
+  Input Format: PEM
   Serial: 13776854720312847553
   Valid: 2017-08-18 19:48 UTC to 2024-06-22 19:48 UTC
   Signature: SHA256-RSA (self-signed)
@@ -88,6 +89,7 @@ Dump an example certificate with name constraints (example-name-constraints.crt)
   \tCert Sign (esc)
   
   ** CERTIFICATE 2 **
+  Input Format: PEM
   Serial: 0
   Valid: 2011-12-06 13:49 UTC to 2031-12-01 13:49 UTC
   Signature: SHA1-RSA (self-signed)

--- a/tests/dump-small-key-to-text.t
+++ b/tests/dump-small-key-to-text.t
@@ -21,6 +21,7 @@ Dump an example certificate (example-leaf.crt)
 
   $ certigo --verbose dump example-small-key.crt
   ** CERTIFICATE 1 **
+  Input Format: PEM
   Serial: 14381893493177441266
   Valid: 2016-06-10 22:14 UTC to 2023-04-15 22:14 UTC
   Signature: SHA256-RSA (self-signed)

--- a/tests/dump-spiffe-cert-to-text.t
+++ b/tests/dump-spiffe-cert-to-text.t
@@ -35,6 +35,7 @@ Dump a SPIFFE example certificate (example-spiffe.crt)
 
   $ certigo --verbose dump example-spiffe.crt
   ** CERTIFICATE 1 **
+  Input Format: PEM
   Serial: 4096
   Valid: 2017-07-19 16:50 UTC to 2017-07-29 16:50 UTC
   Signature: SHA256-RSA


### PR DESCRIPTION
Addresses issue #59 

![image](https://user-images.githubusercontent.com/9165812/75182897-57f4ac00-570f-11ea-9cd1-86c54e1b523f.png)

Shows input format guessed by certigo as `Input Format` field in output