### PR TITLE
no need to print input format when connecting to server

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -163,7 +163,6 @@ func Run(args []string, tty terminal.Terminal) int {
 
 			for i, cert := range result.Certificates {
 				fmt.Fprintf(stdout, "** CERTIFICATE %d **\n", i+1)
-				fmt.Fprintf(stdout, "Input Format: %s\n", result.Formats[i])
 				fmt.Fprintf(stdout, "%s\n\n", lib.EncodeX509ToText(cert, terminalWidth, *verbose))
 			}
 			lib.PrintVerifyResult(stdout, *result.VerifyResult)

--- a/cli/cli_test.go
+++ b/cli/cli_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
@@ -68,6 +70,64 @@ URI Names:
 
 `
 
+const expectedConnect string = `** TLS Connection **
+Version: TLS 1.3
+Cipher Suite: AES_128_GCM_SHA256 cipher
+
+** CERTIFICATE 1 **
+Serial: 64483185769360960274258770740570494187
+Valid: 1970-01-01 00:00 UTC to 2084-01-29 16:00 UTC
+Signature: SHA256-RSA (self-signed)
+Subject Info:
+	Organization: Acme Co
+Issuer Info:
+	Organization: Acme Co
+Basic Constraints: CA:true
+Key Usage:
+	Digital Signature
+	Key Encipherment
+	Cert Sign
+Extended Key Usage:
+	Server Auth
+DNS Names:
+	example.com
+IP Addresses:
+	127.0.0.1, ::1
+Warnings:
+	Size of RSA key should be at least 2048 bits
+
+Failed to verify certificate chain:
+	x509: certificate signed by unknown authority
+** TLS Connection **
+Version: TLS 1.3
+Cipher Suite: AES_128_GCM_SHA256 cipher
+
+** CERTIFICATE 1 **
+Serial: 64483185769360960274258770740570494187
+Valid: 1970-01-01 00:00 UTC to 2084-01-29 16:00 UTC
+Signature: SHA256-RSA (self-signed)
+Subject Info:
+	Organization: Acme Co
+Issuer Info:
+	Organization: Acme Co
+Basic Constraints: CA:true
+Key Usage:
+	Digital Signature
+	Key Encipherment
+	Cert Sign
+Extended Key Usage:
+	Server Auth
+DNS Names:
+	example.com
+IP Addresses:
+	127.0.0.1, ::1
+Warnings:
+	Size of RSA key should be at least 2048 bits
+
+Failed to verify certificate chain:
+	x509: certificate signed by unknown authority
+`
+
 // Test basic dump functionality:  Dump a cert
 func TestDump(t *testing.T) {
 	tmpfile, err := ioutil.TempFile("", t.Name())
@@ -92,4 +152,16 @@ func TestDumpMissingFile(t *testing.T) {
 	const expected = "path 'this-is-a-file-that-definitely-does-not-exist1111.pem' does not exist, try --help\n"
 	assert.Equal(t, expected, testTerminal.ErrorBuf.String())
 	assert.Empty(t, testTerminal.OutputBuf.Bytes())
+}
+
+func TestConnect(t *testing.T) {
+	ts := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	defer ts.Close()
+
+	args := []string{"connect", "--verbose", ts.URL[len("https://"):]}
+	testTerminal := terminal.TestTerminal{Width: 80}
+	Run(args, &testTerminal)
+	assert.EqualValues(t, 0, Run(args, &testTerminal), "process should exit 0")
+	assert.Empty(t, testTerminal.ErrorBuf.Bytes(), "no error output expected")
+	assert.EqualValues(t, expectedConnect, testTerminal.OutputBuf.String())
 }


### PR DESCRIPTION
addresses #213

Only print input format when using dump. Never set this up for connect but inadvertently included print statement. Don't think functionality is useful for connect anyway so just removing the print