### PR TITLE
fix: bump version in cli.go

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,7 +49,7 @@ var (
 )
 
 const (
-	version = "1.12.0"
+	version = "1.12.1"
 )
 
 func Run(args []string, tty terminal.Terminal) int {


### PR DESCRIPTION
The latest released version is 1.12.1 @ f8835d9, however the version
string still reflects version 1.12.0, when run with:

```
$ certigo --version
```

Bump version string to lastest released version.

Signed-off-by: Nick Travers <n.e.travers@gmail.com>