### PR TITLE
Avoid nil deref when using Postgres StartTLS

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -13,6 +13,7 @@ github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/fatih/color v1.9.0 h1:8xPHl4/q1VyqGIPif1F+1V3Y3lSmrq01EabUW3CoW5s=
 github.com/fatih/color v1.9.0/go.mod h1:eQcE1qtQxscV5RaZvpXrrb8Drkc3/DdQ+uUYCNjL+zU=
+github.com/fatih/color v1.10.0 h1:s36xzo75JdqLaaWoiEHk767eHiwo0598uUxyfiPkDsg=
 github.com/fatih/color v1.10.0/go.mod h1:ELkj/draVOlAH/xkhN6mQ50Qd0MPOk5AAr3maGEBuJM=
 github.com/google/uuid v1.0.0 h1:b4Gk+7WdP/d3HZH8EJsZpvV7EtDOgaZLtnaNGIu1adA=
 github.com/google/uuid v1.0.0/go.mod h1:TIyPZe4MgqvfeYDBFedMoGGpEw/LqOeaOT+nhxU+yHo=

--- a/starttls/starttls.go
+++ b/starttls/starttls.go
@@ -247,6 +247,10 @@ func GetConnectionState(startTLSType, connectName, connectTo, identity, clientCe
 		return nil, nil, fmt.Errorf("error connecting: %v", result.err)
 	}
 
+	if cri == nil {
+		return result.state, nil, nil
+	}
+
 	if result.state.Version < tls.VersionTLS12 && *cri != nil {
 		// Sending supported signature schemes was added in TLS 1.2,
 		// but Go lies to us in the GetClientCertificate callback and


### PR DESCRIPTION
Fixes #234