### PR TITLE
Bump version to 1.13.0

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -49,7 +49,7 @@ var (
 )
 
 const (
-	version = "1.12.1"
+	version = "1.13.0"
 )
 
 func Run(args []string, tty terminal.Terminal) int {


### PR DESCRIPTION
It's been a while since we released a new version, so seems like an appropriate time to bump the version.