### PR TITLE
Add the Ed25519 algo to the list of known algo names

### DIFF
--- a/lib/encoder.go
+++ b/lib/encoder.go
@@ -161,6 +161,7 @@ var algoName = [...]string{
 	x509.ECDSAWithSHA256: "ECDSA-SHA256",
 	x509.ECDSAWithSHA384: "ECDSA-SHA384",
 	x509.ECDSAWithSHA512: "ECDSA-SHA512",
+	x509.PureEd25519:     "ED25519",
 }
 
 type basicConstraints struct {


### PR DESCRIPTION
`certigo dump` on an Ed25519 cert before:

```
** CERTIFICATE 1 **
Input Format: PEM
Serial: 1
Valid: 2021-11-30 22:29 UTC to 2023-05-30 22:39 UTC
Signature: 16 (self-signed)
Subject Info:
        CommonName: jdtw
Issuer Info:
        CommonName: jdtw
Subject Key ID: FC:6B:63:10:A7:D5:D6:89:B0:74:DD:05:62:96:32:B4:E5:B9:CC:D4
Basic Constraints: CA:true, pathlen:0
Key Usage:
        Cert Sign
        CRL Sign
```

and after:
```
** CERTIFICATE 1 **
Input Format: PEM
Serial: 1
Valid: 2021-11-30 22:29 UTC to 2023-05-30 22:39 UTC
Signature: ED25519 (self-signed)
Subject Info:
        CommonName: jdtw
Issuer Info:
        CommonName: jdtw
Subject Key ID: FC:6B:63:10:A7:D5:D6:89:B0:74:DD:05:62:96:32:B4:E5:B9:CC:D4
Basic Constraints: CA:true, pathlen:0
Key Usage:
        Cert Sign
        CRL Sign
```
