### PR TITLE
Bump version string to 1.14.1

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -50,7 +50,7 @@ var (
 )
 
 const (
-	version = "1.13.0"
+	version = "1.14.1"
 )
 
 func Run(args []string, tty terminal.Terminal) int {


### PR DESCRIPTION
v1.14.0 has already been released. We'll do a point release to update the version string as reported by the `--version` flag.