### PR TITLE
Don't check OCSP if there are no OCSP servers in the chain

### DIFF
--- a/lib/ocsp.go
+++ b/lib/ocsp.go
@@ -76,6 +76,15 @@ func checkOCSP(chain []*x509.Certificate, ocspStaple []byte) (status *ocsp.Respo
 		return nil, skippedRevocationCheck
 	}
 
+	// Skip if there are no OCSP servers in the chain.
+	numServers := 0
+	for _, cert := range chain[1:] {
+		numServers += len(cert.OCSPServer)
+	}
+	if numServers == 0 {
+		return nil, skippedRevocationCheck
+	}
+
 	retries := maxOCSPValidationRetries
 	if len(ocspStaple) > 0 {
 		// Don't retry if stapled


### PR DESCRIPTION
`certigo` displays the following misleading error when there are no OCSP servers in a chain:

```
 Certificate has OCSP extension, but was unable to check status:
        asn1: syntax error: sequence truncated
```

It tries to parse a zero-length OCSP response. This PR adds an upfront check to bypass OCSP if there aren't any servers in the chain.