### PR TITLE
Remove use of the format list in the connect command

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -180,12 +180,9 @@ func Run(args []string, tty terminal.Terminal) int {
 		result.VerifyResult = &verifyResult
 
 		certList := result.Certificates
-		formatList := result.Formats
 		if *connectFirst && len(certList) > 0 {
 			certList = certList[:1]
-			formatList = formatList[:1]
 			result.Certificates = certList
-			result.Formats = formatList
 		}
 
 		if *connectJSON {


### PR DESCRIPTION
`Format` isn't used in the connect flow (only dump). This leads to a panic:

```
❯ ./certigo connect google.com -l
panic: runtime error: slice bounds out of range [:1] with capacity 0

goroutine 1 [running]:
github.com/square/certigo/cli.Run({0xc000020090, 0x3, 0x3}, {0x14c3378, 0xc000010200})
        /Users/jwood/Development/certigo/cli/cli.go:186 +0x187c
main.main()
        /Users/jwood/Development/certigo/main.go:27 +0x89
```