### PR TITLE
Bump version string to 1.15.1

### DIFF
--- a/cli/cli.go
+++ b/cli/cli.go
@@ -52,7 +52,7 @@ var (
 )
 
 const (
-	version = "1.14.1"
+	version = "1.15.1"
 )
 
 func Run(args []string, tty terminal.Terminal) int {


### PR DESCRIPTION
Although 1.15.0 has been released, the --version flag is still reporting 1.14.1. I suggest a point release to update the version string, similar to #254.