### PR TITLE
Update go command to install certigo

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ Certigo is a utility to examine and validate certificates to help with debugging
 
 To install certigo, simply use:
 
-    go get -u github.com/square/certigo
+    go install github.com/square/certigo@latest
 
 On macOS you can also use homebrew to install:
 


### PR DESCRIPTION
As of Go 1.18, installing executables with `go get` is no longer available. So, I've changed to the `go install` command instead.