### PR TITLE
Switch to using SSLMate's PKCS#12 library

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -12,6 +12,7 @@ require (
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/asn1-ber.v1 v1.0.0-20170511165959-379148ca0225
+	software.sslmate.com/src/go-pkcs12 v0.2.0
 )
 
 go 1.13

--- a/go.sum
+++ b/go.sum
@@ -940,6 +940,7 @@ golang.org/x/crypto v0.0.0-20201002170205-7f63de1d35b0/go.mod h1:LzIPMQfyMNhhGPh
 golang.org/x/crypto v0.0.0-20201124201722-c8d3bf9c5392/go.mod h1:jdWPYTVW3xRLrWPugEBEK3UY2ZEsg3UU495nc5E+M+I=
 golang.org/x/crypto v0.0.0-20210921155107-089bfa567519/go.mod h1:GvvjBRRGRdwPK5ydBHafDWAxML/pGHZbMvKqRZ5+Abc=
 golang.org/x/crypto v0.0.0-20220131195533-30dcbda58838/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
+golang.org/x/crypto v0.0.0-20220331220935-ae2d96664a29/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 h1:kUhD7nTDoI3fVd9G4ORWrbV5NY0liEs/Jg2pv5f+bBA=
 golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4/go.mod h1:IxCIyHEi3zRg3s0A5j5BB6A9Jmi73HwBIUl50j+osU4=
 golang.org/x/exp v0.0.0-20190121172915-509febef88a4/go.mod h1:CJ0aWSM057203Lf6IL+f9T1iT9GByDxfZKAQTCR3kQA=
@@ -1537,4 +1538,6 @@ rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=
 sigs.k8s.io/yaml v1.1.0/go.mod h1:UJmg0vDUVViEyp3mgSv9WPwZCDxu4rQW1olrI1uml+o=
 sigs.k8s.io/yaml v1.2.0 h1:kr/MCeFWJWTwyaHoR9c8EjH9OumOmoF9YGiZd7lFm/Q=
 sigs.k8s.io/yaml v1.2.0/go.mod h1:yfXDCHCao9+ENCvLSE62v9VSji2MKu5jeNfTrofGhJc=
+software.sslmate.com/src/go-pkcs12 v0.2.0 h1:nlFkj7bTysH6VkC4fGphtjXRbezREPgrHuJG20hBGPE=
+software.sslmate.com/src/go-pkcs12 v0.2.0/go.mod h1:23rNcYsMabIc1otwLpTkCCPwUq6kQsTyowttG/as0kQ=
 sourcegraph.com/sourcegraph/appdash v0.0.0-20190731080439-ebfcffb1b5c0/go.mod h1:hI742Nqp5OhwiqlzhgfbWU4mW4yO10fP+LoT9WOswdU=

--- a/lib/certs.go
+++ b/lib/certs.go
@@ -35,7 +35,7 @@ import (
 
 	"github.com/square/certigo/jceks"
 	"github.com/square/certigo/pkcs7"
-	"golang.org/x/crypto/pkcs12"
+	"software.sslmate.com/src/go-pkcs12"
 )
 
 const (


### PR DESCRIPTION
Switch to using SSLMate's PKCS#12 library. The previous golang.org/x/crypto/pkcs12 library is frozen and not supported anymore. In particular, it doesn't support newer algorithms which are now seemingly the default in later versions of OpenSSL.

Here's an example of a PKCS#12 keystore (base64-encoded) generated with OpenSSL 3.0.2 which works with SSLMate's PKCS#12 library but does not work for me with the old Golang one:
```
MIIKbwIBAzCCCiUGCSqGSIb3DQEHAaCCChYEggoSMIIKDjCCBIIGCSqGSIb3DQEHBqCCBHMwggRv
AgEAMIIEaAYJKoZIhvcNAQcBMFcGCSqGSIb3DQEFDTBKMCkGCSqGSIb3DQEFDDAcBAivcQ20H0aH
OQICCAAwDAYIKoZIhvcNAgkFADAdBglghkgBZQMEASoEEHzE5Z2ddnTWOiodBgkfB4CAggQAEam0
MCMMR+rwAkrERxrGBAeOWHSTZgclZLu99cJX1LrBlxWhmbdLKLcNL8R+ZyF82D5ztF1Jy4gNfW5+
+9cro0u3SaPKBQM85/dI9pnGIveEYjK4VP/HRyaEmGHL85X1oqY7dJpfdqW78ZI6sCX9mIhkRY28
A0BkOyTJSYYFdM240vaWABLUUUY9nP/iq/+j+sa1BdK6G2eu2mf7/ZlusDYCc23r8Msqo+wSNDuz
tTq11ELCFvutpafp6AYUwu/FBW3xMcu+maaayoSzyVZdBW3+D/GWc3zjHr+4zvd8vqgTEPGORpsF
diIo76GErNK1dLZt3Bvc9D27wYwboa4ZW0C860DuVJrj8nuh8dONjj1g5nNOpIl87rSLoPgmHgSX
udx4xFLw9MBmSEPTH0vxtxb+J2g1/y86DlQhBqW4thHeG1l3eRIB379Qdp36AhsVvulWXoO8ewg7
gIdSHbHHYhqIaqsQVREO9lds2IACeAxtapMnyUHfRep2vFJ/N38zH4XKsFtLb3cnRjZjtVFNTcuT
AhIuz6JulrKrxzuWSZPi8orL5B0V17UDgYPJ9YclD/U/JfqwR4ldiZGusPLAXGKBJwinJb5O+zIO
jRxsrgN6mlYHt1+lHQvzku+h9fo/6T6nPG4Z0J0jaGlZra44OaWp1zdqCgM3Fdfj9RVkcBqPFxSx
5iHOjpaTOgfww1KQ+AWBoWWe3qfQ6HcIbEUxndl4+I+H8qOtN0j7OFD6r0iAA/yQJN1BRdKVIfbW
GuCSp8O48awLaCJDILygc1XoQtnRNcsvB1B755v7hyV+4fZxGCAGgqJyrLyEewVY/Ifwp38AEvNZ
uGKGVRV8OxU2OB5NucxD9ZQKitUO+htW5YTTCQb35llbfa/kXNfpxo8vmfSA/sWjOrWnjUBDureM
wWfW1bi7LrofGezu3fAZ3u618TiaF0aGieBsp0QgMppZ7kvllgBiFKJ5UL1M97zNEDnsiICiTfMB
RPrE1VMGAKaIestBeOEmnd3DpYcHuLVwqeSi/nK/aV9T5SK4sAny6iVaTprZDZfQO8IKkympdLOJ
g1rAZKuDeanGGVtrhcq1Zmx/Es6Wpn9kd1/4HlfcuKAby0AoZbPIK00vnUejOpcvbxRU/vlAPEkb
SBOvPwSphWJ2GXNHyRKBygb4jUYh2JrKQCI09f6VeyJEEf2bpcz2QSdqLKMaFeQvKxMxNFHs7YCd
gFsRmCtNuDBtu5uWNeknmmO7dEZ8NE4ywJ9SLJgNvLEUOlASTqUbPieivqE4L7fCjLbY3zKRqTLH
LH19eXWogSexRI8/uXo58daO4M+1RLWC3sV6drDJwlekzqJKZTaQYzhLD1EIO+S41WxjoTCCBYQG
CSqGSIb3DQEHAaCCBXUEggVxMIIFbTCCBWkGCyqGSIb3DQEMCgECoIIFMTCCBS0wVwYJKoZIhvcN
AQUNMEowKQYJKoZIhvcNAQUMMBwECBINKad5XWLlAgIIADAMBggqhkiG9w0CCQUAMB0GCWCGSAFl
AwQBKgQQO/fyH9rsTEVaxd+Sk8RorwSCBNCLm7SzKPTGMQA5xg3m0C8DOnbuALI0CHKdJemX9azd
Ms23Qlqn5MigC4AVyxFRG392rjjjIx6xsew6zxh/p9K0PCR2A7TlpRtltNiB38sF7VGHVft0vu/1
W46cxjyHn0BbbtQtkFw6+kSx6z2KgxhBqeQfSw0EooBpHpt8T4DGeDeyhap2SI9OOeia8tQYEllh
5UDlS3bbGO0xJbE8UVBEYKD1QNMzMtbITtTefeOz1dxU4fD9O9Dxd0Pubhi2q4CL7PEISdkOpHvi
ej5hYPcwPtoTi4oHaZEIKHdO5v0inpSCDCn88X+SO89VYctWia5X3Kjf0CqG2UE81LQAVgR6GkTa
gO9UzIV5KyAugMgHYXmiWYLlYIY7jQBfQFzt+n+WP3nuYHihe41MXSZN8yu71Uf0IO96GPUzYmwK
GkMEfywWIADpBSfq3GE3GPR00tPK2iSbSvjWcMWZBLF0qwvc+ICe7G/eoYMFD/Bc00lEgzN3RztF
Y7OomkVSZJM6OwGIScvwk/rsZjry9Qx5ojdv8WglX8/QAl6sG5bJp6/HlzeDuOVHEJLVDx1qnCZO
vH8OnbwbMqMw34yx0EtJBjL0KWTv6SOt4AMKJm+uwc9k2s8fz1ZjSiOXLz0WkqIoQsVc2VX1nPXO
0RB5SEkbmACiCGOEvvk5Ku/av0jeIabBo/L4QHPI1gG/Tvh0t8QE1ERC90N8XRnBFdbthZRYVsMi
ASLCnINZ196OmcbWXwmtwyNRYxPD/55pxSG7Q9SzIDwictUSVNL1cX7i6SrREFxZ9k39euBtpYLi
KGUGc8jkoovtYPeInIOR7wOg6wEIcZHTFJN9o57j44hIDD7X39NSLoXvjCD9TJ8lBhHjJxfM4aVd
HkpnzsSpWRKoWQK263N2W8Oa2nM3nRFZ8F0QKpDOM1edPCW0HHlgo1dusuvVL7sPf/qYN6bEBfsw
/8DoMD82iWCxRckmZnjGVPRk7MtCyZFkT4knZBCC0MoOUs1WB7X3zRfTe9uPwahbzWI06ryyTivq
zR6yqAyI++dBToxSRmLQyJyFcm2g9dD5ZOw/m4wKZPX6leJuRykbmYf2RJ3qFGlwKpe4yJbP1YXE
rMnESr+kmN3lQxxt29F7W65XESHF+JyftppUjEMNxIrkOAklmzan1S3gPkuPOD2dU3BPtPlwhpWN
TgY912p794dLUD3Evlq2bRLfZSnSvjG4ZMUstUxizh7/1esqMHQcTemvKFu+4N9/2oNRKZjRXNNp
xMPazWYBUR1AAXvdH8nSbI1XMI6o+FT2/jOfXL7YIrLzgNHCA5oKpArQGQL5zZRPNtdkjZ+ZdwYW
fSkN3K7yFeL5wsca52pU+9R61bxGfoIlT4KIXy4s9zGXsPBI+Ek68BKJobzBgaFyGuiIP0B82mGE
BTVHKCz/JkrJsGem7IZGH9zWtMNdRKb7VfW3wFdYMVSUereEgWz/teaCl6FxJ7ey53xZvpqtHiAS
B3yyyeds1P1PIe31y5EB2BYLVo+cHDWFIZl4vzlnTwss5EUERGTgPNuHSX71RHIsd0E7I7G6DieG
bgYntDM+YujoXH18lggGkG9F23TcfqWmHm4QT03bT7XhDavEJ9gSPh90NsALEMVPDiH869q0tmFN
JZkjkzElMCMGCSqGSIb3DQEJFTEWBBQMqFoOUpImZR9h8RbJ8onW9RBMZTBBMDEwDQYJYIZIAWUD
BAIBBQAEIGYDBO/MNhIlTJzACtcsPuH1Xl9tY+sfXY+BoHd+6pVrBAgExeZcBXzzFwICCAA=
```

(Had to base64-encode this because attaching binary files didn't seem to work).