### PR TITLE
Update to latest stable Go toolchain

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -10,9 +10,16 @@ jobs:
     name: Lint
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
-      - name: golangci-lint
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Go environment
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          check-latest: true
+      - name: Golangci-lint
         uses: golangci/golangci-lint-action@v8
         with:
           version: v2.1.0
+          install-mode: goinstall
           only-new-issues: true

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,23 +10,24 @@ jobs:
     name: Build
     strategy:
       matrix:
-        version: [1.19.x]
+        version: ['stable']
         target:
           - { os: 'darwin', platform: 'macos-latest', arch: 'amd64' }
           - { os: 'linux', platform: 'ubuntu-latest', arch: 'amd64' }
           - { os: 'windows', platform: 'windows-latest', arch: 'amd64' }
     runs-on: ${{ matrix.target.platform }}
     steps:
-      - name: Set up toolchain
+      - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
           go-version: ${{ matrix.version }}
+          check-latest: true
         id: go
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Build binary
         run: go build -o certigo .
-      - name: Upload artifact
+      - name: Upload a Build Artifact
         uses: actions/upload-artifact@v4
         with:
           name: certigo-${{ matrix.target.os }}-${{ matrix.target.arch }}
@@ -39,7 +40,8 @@ jobs:
     outputs:
       upload_url: ${{ steps.create_release.outputs.upload_url }}
     steps:
-      - uses: actions/checkout@v4
+      - name: Checkout
+        uses: actions/checkout@v4
       - name: Create release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,12 +12,13 @@ jobs:
     name: Unit tests
     runs-on: ubuntu-latest
     steps:
-      - name: Check out code
+      - name: Checkout
         uses: actions/checkout@v4
-      - name: Set up Go
+      - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: '1.19.x'
+          go-version: 'stable'
+          check-latest: true
       - name: Build binary
         run: go build
       - name: Run tests
@@ -26,17 +27,18 @@ jobs:
     name: Integration tests
     runs-on: ubuntu-latest
     steps:
-      - name: Set up Go
+      - name: Setup Go environment
         uses: actions/setup-go@v5
         with:
-          go-version: '1.19.x'
-      - name: Set up Python
+          go-version: 'stable'
+          check-latest: true
+      - name: Setup Python
         uses: actions/setup-python@v5
         with:
           python-version: '3.x'
       - name: Install cram
-        run: pip install cram --user
-      - name: Check out code
+        run: pip install cram
+      - name: Checkout
         uses: actions/checkout@v4
       - name: Build binary
         run: go build

--- a/build
+++ b/build
@@ -1,6 +1,9 @@
 #!/bin/bash -e
 # Copyright (C) 2016 Square, Inc.
 
+# This script is for use by the Homebrew build toolchain.
+# To build or install certigo in most cases, use the standard Go toolchain described in the README.
+
 ORG_PATH="github.com/square"
 REPO_PATH="${ORG_PATH}/certigo"
 


### PR DESCRIPTION
The latest version of the Go compiler is always the best compiler for old versions of the language, so this commit upgrades from 1.19 to stable (currently 1.24).

Also added a small comment about the purpose of `./build`