### PR TITLE
Fix current linter findings

### DIFF
--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -1,0 +1,27 @@
+version: "2"
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - staticcheck
+    - unused
+  exclusions:
+    generated: lax
+    presets:
+      - comments
+      - common-false-positives
+      - legacy
+      - std-error-handling
+    paths:
+      - starttls/ldap/
+      - starttls/mysql/
+      - starttls/psql/
+formatters:
+  exclusions:
+    generated: lax
+    paths:
+      - starttls/ldap/
+      - starttls/mysql/
+      - starttls/psql/

--- a/cli/terminal/terminal.go
+++ b/cli/terminal/terminal.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/mattn/go-colorable"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/crypto/ssh/terminal" //nolint:staticcheck // TODO: Change dependencies when upgrading to Go >= 1.17
 )
 
 const minWidth = 60
@@ -53,19 +53,19 @@ func (t *TTY) ReadPassword(prompt string) string {
 	if err != nil {
 		tty = os.Stdin
 	} else {
-		defer tty.Close()
+		defer func() { _ = tty.Close() }()
 	}
 
-	tty.WriteString("Enter password")
+	_, _ = tty.WriteString("Enter password")
 	if prompt != "" {
-		tty.WriteString(fmt.Sprintf(" for entry [%s]", prompt))
+		_, _ = fmt.Fprintf(tty, " for entry [%s]", prompt)
 	}
-	tty.WriteString(": ")
+	_, _ = tty.WriteString(": ")
 
 	password, err := terminal.ReadPassword(int(tty.Fd()))
-	tty.WriteString("\n")
+	_, _ = tty.WriteString("\n")
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "error reading password: %s\n", err)
+		_, _ = fmt.Fprintf(os.Stderr, "error reading password: %s\n", err)
 		os.Exit(1)
 	}
 

--- a/jceks/pbe.go
+++ b/jceks/pbe.go
@@ -37,17 +37,17 @@ type pbeParameters struct {
 
 // Here's how this algorithm works:
 //
-// 1. Split salt in two halves. If the two halves are identical,
-//    invert one of them.
-// 2. Concatenate password with each of the halves.
-// 3. Digest each concatenation with c iterations, where c is the
-//    iterationCount. Concatenate the output from each digest round with the
-//    password, and use the result as the input to the next digest operation.
-//    The digest algorithm is MD5.
-// 4. After c iterations, use the 2 resulting digests as follows:
-//    The 16 bytes of the first digest and the 1st 8 bytes of the 2nd digest
-//    form the triple DES key, and the last 8 bytes of the 2nd digest form the
-//    IV.
+//  1. Split salt in two halves. If the two halves are identical,
+//     invert one of them.
+//  2. Concatenate password with each of the halves.
+//  3. Digest each concatenation with c iterations, where c is the
+//     iterationCount. Concatenate the output from each digest round with the
+//     password, and use the result as the input to the next digest operation.
+//     The digest algorithm is MD5.
+//  4. After c iterations, use the 2 resulting digests as follows:
+//     The 16 bytes of the first digest and the 1st 8 bytes of the 2nd digest
+//     form the triple DES key, and the last 8 bytes of the 2nd digest form the
+//     IV.
 func recoverPBEWithMD5AndDES3CBC(
 	algo pkix.AlgorithmIdentifier, encryptedKey, password []byte) ([]byte, error) {
 	var params pbeParameters
@@ -66,7 +66,7 @@ func recoverPBEWithMD5AndDES3CBC(
 		return nil, fmt.Errorf("unexpected salt length: %d", len(salt))
 	}
 
-	if bytes.Compare(salt[0:4], salt[4:]) == 0 {
+	if bytes.Equal(salt[0:4], salt[4:]) {
 		// First and second half of salt are equal, invert first half.
 		for i := 0; i < 2; i++ {
 			salt[i], salt[3-i] = salt[3-i], salt[i]

--- a/lib/certs.go
+++ b/lib/certs.go
@@ -33,9 +33,10 @@ import (
 	"reflect"
 	"strings"
 
+	"software.sslmate.com/src/go-pkcs12"
+
 	"github.com/square/certigo/jceks"
 	"github.com/square/certigo/pkcs7"
-	"software.sslmate.com/src/go-pkcs12"
 )
 
 const (
@@ -66,6 +67,7 @@ var badSignatureAlgorithms = [...]x509.SignatureAlgorithm{
 	x509.ECDSAWithSHA1,
 }
 
+// TODO: replace misuse of error type in future version (errors should not act as multi-line output templates)
 func errorFromErrors(errs []error) error {
 	if len(errs) == 0 {
 		return nil
@@ -109,7 +111,7 @@ func ReadAsPEMFromFiles(files []*os.File, format string, password func(string) s
 // PKCS12/JCEKS keystores. All inputs will be converted to PEM blocks and
 // passed to the callback.
 func ReadAsPEM(readers []io.Reader, format string, password func(string) string, callback func(*pem.Block, string) error) error {
-	errs := []error{}
+	var errs []error
 	for _, r := range readers {
 		reader := bufio.NewReaderSize(r, 4)
 		format, err := formatForFile(reader, "", format)
@@ -130,7 +132,7 @@ func ReadAsPEM(readers []io.Reader, format string, password func(string) string,
 // or PKCS7 envelopes, or PKCS12/JCEKS keystores. All inputs will be converted
 // to X.509 certificates (private keys are skipped) and passed to the callback.
 func ReadAsX509FromFiles(files []*os.File, format string, password func(string) string, callback func(*x509.Certificate, string, error) error) error {
-	errs := []error{}
+	var errs []error
 	for _, file := range files {
 		reader := bufio.NewReaderSize(file, 4)
 		format, err := formatForFile(reader, file.Name(), format)
@@ -151,7 +153,7 @@ func ReadAsX509FromFiles(files []*os.File, format string, password func(string) 
 // envelopes, or PKCS12/JCEKS keystores. All inputs will be converted to X.509
 // certificates (private keys are skipped) and passed to the callback.
 func ReadAsX509(readers []io.Reader, format string, password func(string) string, callback func(*x509.Certificate, string, error) error) error {
-	errs := []error{}
+	var errs []error
 	for _, r := range readers {
 		reader := bufio.NewReaderSize(r, 4)
 		format, err := formatForFile(reader, "", format)
@@ -212,7 +214,7 @@ func readCertsFromStream(reader io.Reader, filename string, format string, passw
 	case "DER":
 		data, err := io.ReadAll(reader)
 		if err != nil {
-			return fmt.Errorf("unable to read input: %s\n", err)
+			return fmt.Errorf("unable to read input: %s\n", err) //nolint:staticcheck // See errorFromErrors
 		}
 		x509Certs, err0 := x509.ParseCertificates(data)
 		if err0 == nil {
@@ -234,14 +236,20 @@ func readCertsFromStream(reader io.Reader, filename string, format string, passw
 			}
 			return nil
 		}
+		//nolint:staticcheck // See errorFromErrors
 		return fmt.Errorf("unable to parse certificates from DER data\n* X.509 parser gave: %s\n* PKCS7 parser gave: %s\n", err0, err1)
 	case "PKCS12":
 		data, err := io.ReadAll(reader)
 		if err != nil {
-			return fmt.Errorf("unable to read input: %s\n", err)
+			return fmt.Errorf("unable to read input: %s\n", err) //nolint:staticcheck // See errorFromErrors
 		}
-		blocks, err := pkcs12.ToPEM(data, password(""))
-		if err != nil || len(blocks) == 0 {
+		blocks, err := pkcs12ToPemBlocks(data, password(""))
+		if err != nil {
+			//nolint:staticcheck // See errorFromErrors
+			return fmt.Errorf("unable to read keystore: %s\n", err)
+		}
+		if len(blocks) == 0 {
+			//nolint:staticcheck // See errorFromErrors
 			return fmt.Errorf("keystore appears to be empty or password was incorrect\n")
 		}
 		for _, block := range blocks {
@@ -255,7 +263,7 @@ func readCertsFromStream(reader io.Reader, filename string, format string, passw
 	case "JCEKS":
 		keyStore, err := jceks.LoadFromReader(reader, []byte(password("")))
 		if err != nil {
-			return fmt.Errorf("unable to parse keystore: %s\n", err)
+			return fmt.Errorf("unable to parse keystore: %s\n", err) //nolint:staticcheck // See errorFromErrors
 		}
 		for _, alias := range keyStore.ListCerts() {
 			cert, _ := keyStore.GetCert(alias)
@@ -267,6 +275,7 @@ func readCertsFromStream(reader io.Reader, filename string, format string, passw
 		for _, alias := range keyStore.ListPrivateKeys() {
 			key, certs, err := keyStore.GetPrivateKeyAndCerts(alias, []byte(password(alias)))
 			if err != nil {
+				//nolint:staticcheck // See errorFromErrors
 				return fmt.Errorf("unable to parse keystore: %s\n", err)
 			}
 
@@ -274,7 +283,7 @@ func readCertsFromStream(reader io.Reader, filename string, format string, passw
 
 			block, err := keyToPem(key, mergedHeaders)
 			if err != nil {
-				return fmt.Errorf("problem reading key: %s\n", err)
+				return fmt.Errorf("problem reading key: %s\n", err) //nolint:staticcheck // See errorFromErrors
 			}
 
 			if err := callback(block, format); err != nil {
@@ -289,7 +298,7 @@ func readCertsFromStream(reader io.Reader, filename string, format string, passw
 		}
 		return nil
 	}
-	return fmt.Errorf("unknown file type '%s'\n", format)
+	return fmt.Errorf("unknown file type '%s'\n", format) //nolint:staticcheck // See errorFromErrors
 }
 
 func mergeHeaders(baseHeaders, extraHeaders map[string]string) (headers map[string]string) {
@@ -333,6 +342,7 @@ func keyToPem(key crypto.PrivateKey, headers map[string]string) (*pem.Block, err
 	case *ecdsa.PrivateKey:
 		raw, err := x509.MarshalECPrivateKey(k)
 		if err != nil {
+			//nolint:staticcheck // See errorFromErrors
 			return nil, fmt.Errorf("error marshaling key: %s\n", reflect.TypeOf(key))
 		}
 		return &pem.Block{
@@ -341,7 +351,40 @@ func keyToPem(key crypto.PrivateKey, headers map[string]string) (*pem.Block, err
 			Headers: headers,
 		}, nil
 	}
+	//nolint:staticcheck // See errorFromErrors
 	return nil, fmt.Errorf("unknown key type: %s\n", reflect.TypeOf(key))
+}
+
+// pkcs12ToPemBlocks converts all PKCS#12 safe bags in data to PEM blocks.
+func pkcs12ToPemBlocks(data []byte, password string) ([]*pem.Block, error) {
+	// pkcs12.ToPEM is deprecated because it returns "PRIVATE KEY" PEM blocks that are not in PKCS#8 format, but rather
+	// in a format specific to the key type. However, the pkcs12 package does not provide an equivalent replacement:
+	// there is no other way to preserve the order of the safe bag contents or to preserve "friendlyName", "localKeyId",
+	// and "Microsoft CSP Name" attributes that may be present in the PKCS#12 data. Therefore, this function calls the
+	// deprecated function and then attempts to fix the invalid PEM blocks by giving them appropriate block types.
+	//nolint:staticcheck // See comment
+	blocks, err := pkcs12.ToPEM(data, password)
+	if err != nil {
+		return nil, fmt.Errorf("failed to parse PKCS#12 data: %w", err)
+	}
+	for _, block := range blocks {
+		if block.Type != "PRIVATE KEY" {
+			continue
+		}
+		if _, parseErr := x509.ParseECPrivateKey(block.Bytes); parseErr == nil {
+			block.Type = "EC PRIVATE KEY"
+			continue
+		}
+		if _, parseErr := x509.ParsePKCS1PrivateKey(block.Bytes); parseErr == nil {
+			block.Type = "RSA PRIVATE KEY"
+			continue
+		}
+
+		//nolint:staticcheck // See errorFromErrors
+		return nil, fmt.Errorf("PKCS#12 conversion produced unknown private key type\n")
+	}
+
+	return blocks, nil
 }
 
 // formatForFile returns the file format (either from flags or
@@ -361,7 +404,7 @@ func formatForFile(file *bufio.Reader, filename, format string) (string, error) 
 	// Third, attempt to guess based on first 4 bytes of input
 	data, err := file.Peek(4)
 	if err != nil {
-		return "", fmt.Errorf("unable to read file: %s\n", err)
+		return "", fmt.Errorf("unable to read file: %s\n", err) //nolint:staticcheck // See errorFromErrors
 	}
 
 	// Heuristics for guessing -- best effort.

--- a/lib/tls.go
+++ b/lib/tls.go
@@ -94,8 +94,12 @@ func EncodeTLSInfoToText(tcs *tls.ConnectionState, cri *tls.CertificateRequestIn
 		// Should never happen
 		panic(err)
 	}
-	w.Flush()
-	return string(buffer.Bytes())
+	err = w.Flush()
+	if err != nil {
+		// Should never happen
+		panic(err)
+	}
+	return buffer.String()
 }
 
 // EncodeTLSToObject returns a JSON-marshallable description of a TLS connection
@@ -157,7 +161,7 @@ var qualityColors = map[uint8]*color.Color{
 }
 
 var tlsVersions = map[uint16]description{
-	tls.VersionSSL30: {"SSL 3.0", "ssl_3_0", insecure},
+	tls.VersionSSL30: {"SSL 3.0", "ssl_3_0", insecure}, //nolint:staticcheck // Support for now
 	tls.VersionTLS10: {"TLS 1.0", "tls_1_0", insecure},
 	tls.VersionTLS11: {"TLS 1.1", "tls_1_1", ok},
 	tls.VersionTLS12: {"TLS 1.2", "tls_1_2", good},

--- a/lib/verify.go
+++ b/lib/verify.go
@@ -17,6 +17,7 @@
 package lib
 
 import (
+	"crypto/tls"
 	"crypto/x509"
 	"encoding/json"
 	"encoding/pem"
@@ -26,8 +27,6 @@ import (
 	"os"
 	"strings"
 	"time"
-
-	"crypto/tls"
 
 	"golang.org/x/crypto/ocsp"
 )
@@ -86,7 +85,7 @@ func caBundle(caPath string) (*x509.CertPool, error) {
 
 	caFile, err := os.Open(caPath)
 	if err != nil {
-		return nil, fmt.Errorf("error opening CA bundle %s: %s\n", caPath, err)
+		return nil, fmt.Errorf("error opening CA bundle %s: %w", caPath, err)
 	}
 
 	bundle := x509.NewCertPool()
@@ -99,14 +98,14 @@ func caBundle(caPath string) (*x509.CertPool, error) {
 		},
 		func(cert *x509.Certificate, format string, err error) error {
 			if err != nil {
-				return fmt.Errorf("error parsing CA bundle: %s\n", err)
+				return fmt.Errorf("error parsing CA bundle: %w", err)
 			} else {
 				bundle.AddCert(cert)
 			}
 			return nil
 		})
 	if err != nil {
-		return nil, fmt.Errorf("error parsing CA bundle: %s\n", err)
+		return nil, fmt.Errorf("error parsing CA bundle: %w", err)
 	}
 	return bundle, nil
 }
@@ -129,7 +128,7 @@ func VerifyChain(certs []*x509.Certificate, ocspStaple []byte, expectedName, caP
 
 	roots, err := caBundle(caPath)
 	if err != nil {
-		result.Error = fmt.Sprintf("%s", err)
+		result.Error = err.Error() + "\n"
 		return result
 	}
 	// expectedName could be a hostname or could be a SPIFFE ID (spiffe://...)
@@ -149,7 +148,7 @@ func VerifyChain(certs []*x509.Certificate, ocspStaple []byte, expectedName, caP
 
 	chains, err := certs[0].Verify(opts)
 	if err != nil {
-		result.Error = fmt.Sprintf("%s", err)
+		result.Error = err.Error()
 		return result
 	}
 
@@ -158,7 +157,7 @@ func VerifyChain(certs []*x509.Certificate, ocspStaple []byte, expectedName, caP
 		// SPIFFE ID. We thus perform this check explicitly here.
 		err = verifyCertificateSPIFFEIDMatch(certs[0], expectedName)
 		if err != nil {
-			result.Error = fmt.Sprintf("%s", err)
+			result.Error = err.Error()
 			return result
 		}
 	}
@@ -204,8 +203,8 @@ func fmtCert(cert simpleVerifyCert) string {
 
 func PrintVerifyResult(out io.Writer, result SimpleVerification) {
 	if result.Error != "" {
-		fmt.Fprintf(out, red.SprintfFunc()("Failed to verify certificate chain:\n"))
-		fmt.Fprintf(out, "\t%s\n", result.Error)
+		_, _ = fmt.Fprint(out, red.SprintlnFunc()("Failed to verify certificate chain:"))
+		_, _ = fmt.Fprintf(out, "\t%s\n", result.Error)
 		return
 	}
 
@@ -214,22 +213,22 @@ func PrintVerifyResult(out io.Writer, result SimpleVerification) {
 }
 
 func printCertificateChains(out io.Writer, result SimpleVerification) {
-	fmt.Fprintf(out, green.SprintfFunc()("Found %d valid certificate chain(s):\n", len(result.Chains)))
+	_, _ = fmt.Fprint(out, green.SprintfFunc()("Found %d valid certificate chain(s):\n", len(result.Chains)))
 	for i, chain := range result.Chains {
-		fmt.Fprintf(out, "[%d] %s\n", i, fmtCert(chain[0]))
+		_, _ = fmt.Fprintf(out, "[%d] %s\n", i, fmtCert(chain[0]))
 		for j, cert := range chain {
 			if j == 0 {
 				continue
 			}
-			fmt.Fprintf(out, "\t=> %s\n", fmtCert(cert))
+			_, _ = fmt.Fprintf(out, "\t=> %s\n", fmtCert(cert))
 		}
 	}
 }
 
 func printOCSPStatus(out io.Writer, result SimpleVerification) {
 	if result.OCSPError != "" {
-		fmt.Fprintf(out, red.SprintfFunc()("Certificate has OCSP extension, but was unable to check status:\n"))
-		fmt.Fprintf(out, "\t%s\n\n", result.OCSPError)
+		_, _ = fmt.Fprint(out, red.SprintlnFunc()("Certificate has OCSP extension, but was unable to check status:"))
+		_, _ = fmt.Fprintf(out, "\t%s\n\n", result.OCSPError)
 		return
 	}
 
@@ -249,8 +248,8 @@ func printOCSPStatus(out io.Writer, result SimpleVerification) {
 			wasStapled = " (was stapled)"
 		}
 
-		fmt.Fprintf(out, color.SprintfFunc()("Checked OCSP status for certificate%s, got:", wasStapled))
-		fmt.Fprintf(out, "\n\t%s (last update: %s)", status, result.OCSPStatus.ProducedAt.Format(time.RFC822))
+		_, _ = fmt.Fprint(out, color.SprintfFunc()("Checked OCSP status for certificate%s, got:", wasStapled))
+		_, _ = fmt.Fprintf(out, "\n\t%s (last update: %s)", status, result.OCSPStatus.ProducedAt.Format(time.RFC822))
 
 		if result.OCSPStatus.Status == ocsp.Revoked {
 			reason, ok := revocationReasonDescription[result.OCSPStatus.RevocationReason]
@@ -258,10 +257,10 @@ func printOCSPStatus(out io.Writer, result SimpleVerification) {
 				reason = "Unknown"
 			}
 
-			fmt.Fprintf(out, "\n\tWas revoked at %s due to: %s", result.OCSPStatus.RevokedAt.Format(time.RFC822), reason)
+			_, _ = fmt.Fprintf(out, "\n\tWas revoked at %s due to: %s", result.OCSPStatus.RevokedAt.Format(time.RFC822), reason)
 		}
 
-		fmt.Fprintf(out, "\n\n")
+		_, _ = fmt.Fprint(out, "\n\n")
 	}
 }
 
@@ -301,17 +300,17 @@ func verifySPIFFEIDMatch(expected string, actual string) error {
 
 	// Verify both have "spiffe" as the scheme (case-insensitive)
 	if !strings.HasPrefix(strings.ToLower(expected), "spiffe://") {
-		return fmt.Errorf("Expected scheme is not \"spiffe\"")
+		return fmt.Errorf("expected scheme is not \"spiffe\"")
 	}
 	if !strings.HasPrefix(strings.ToLower(actual), "spiffe://") {
-		return fmt.Errorf("Actual scheme is not \"spiffe\"")
+		return fmt.Errorf("actual scheme is not \"spiffe\"")
 	}
 
 	// Verify that everything after the scheme equals in a case-sensitive way
 	expectedRemainder := expected[len("spiffe://"):]
 	actualRemainder := actual[len("spiffe://"):]
 	if expectedRemainder != actualRemainder {
-		return fmt.Errorf("Trust domain and/or path do not match")
+		return fmt.Errorf("trust domain and/or path do not match")
 	}
 
 	// They match

--- a/starttls/dialer.go
+++ b/starttls/dialer.go
@@ -49,7 +49,7 @@ func dialWithDialer(dialer Dialer, timeout time.Duration, network, addr string, 
 	}
 
 	if err != nil {
-		rawConn.Close()
+		_ = rawConn.Close()
 		return nil, err
 	}
 

--- a/tests/dump-pkcs12-chain-to-pem.t
+++ b/tests/dump-pkcs12-chain-to-pem.t
@@ -143,7 +143,7 @@ Dump PEM blocks from a PKCS12 keystore. Multiple pem blocks are displayed
   6hRqpe+kXdFNpxj/83JGXGLpU6obNBGg27n4o2SINsIIHci6mDGi0mbs08eEkyqL
   2GbYHPp6z2n/UQ==
   -----END CERTIFICATE-----
-  -----BEGIN PRIVATE KEY-----
+  -----BEGIN RSA PRIVATE KEY-----
   MIIEowIBAAKCAQEAvHeFpNHWCsjV47fwXvmV5HpKdoPqm6j1UlfUFJyXxmxY0KoT
   pdXoWP5DktZZiO6L2plb64t0UKxh/KyHOO8nv7bE7BMBsAc/oYmMmqou5oDVyEWA
   Ud6llVN7TN/3o8DVMORwIgt54TDqqCiLylp9DETd4uUsg9hhAwLRjtAyTQH/lQVO
@@ -169,4 +169,4 @@ Dump PEM blocks from a PKCS12 keystore. Multiple pem blocks are displayed
   4DdpAoGBALFruy/DW2urx5oFyppFv0xVLuRHzwW5gFyVSoa2/7TElBBQ7luXOVvX
   QulcA8LTBbp9ZlJ6O5SrNKZW3QpSWeuRoGaxsfs6Yq1sGDbyiWtuufDknAqEiZg6
   LGdAI9LSB35HihR3AzNW+FsQ3p1aiEuWETFH9BaNLE2CdVJ7mLlT
-  -----END PRIVATE KEY-----
+  -----END RSA PRIVATE KEY-----

--- a/tests/dump-pkcs12-to-pem.t
+++ b/tests/dump-pkcs12-to-pem.t
@@ -78,7 +78,7 @@ Dump PEM blocks from a PKCS12 keystore.
   ZiD1Idajj0tj/rT5/M1K/ZLEiOzXVpo/+l/+hoXw9eVnRa2nBwjoiZ9cMuGKUpHm
   YSv7SyFevNwDwcxcAq6uVitKi0YCqHiNZ7Ye3/BGRDUFpK2IASUo8YbXYNyA/6nu
   -----END CERTIFICATE-----
-  -----BEGIN PRIVATE KEY-----
+  -----BEGIN RSA PRIVATE KEY-----
   MIIEowIBAAKCAQEAs6JY7Hm/NAsH3nuMOOSBno6WmwsTYEw3hk4eyprWiI/Npoia
   iZVCGahT8NAKqLDW5t9vgKz6c4ffi5/aQ2scichq3QS7pELAYlS4b+ey3dA6hj62
   MOTTO4Ad5bFbbRZG+Mdm2Ayvl6eV6catQhMvxt7aIoY9+bodyIYC1zZVqwQ5sOT+
@@ -104,4 +104,4 @@ Dump PEM blocks from a PKCS12 keystore.
   D9+3nQKBgGlX4cwGan4tBVBHorU8925Gk6nmyrzPQ+riA+KYiPXIZ5/WtPAhV86D
   GtZ2VVSqRprAcwQopp9SBfnFy0NHErrPm2telmIRqlxii9ipda4Tek2QgGoREOrq
   gjzEnBf5gy/YRJkylVeH9FY7+HsaBO4kSEOH7GIOe0UpcShJKd+6
-  -----END PRIVATE KEY-----
+  -----END RSA PRIVATE KEY-----


### PR DESCRIPTION
This commit adds an explicit `golangci-lint` configuration that simply matches the default linters previously in use, and then fixes all current linter findings.

Aside from tweaking error message strings, this commit introduces one externally visible behavior change: PEM data generated from PKCS#12 files now correctly identifies private key blocks as `RSA PRIVATE KEY` or `EC PRIVATE KEY`, whereas previously it generated invalid `PRIVATE KEY` blocks with non-PKCS#8 data.

This commit lays the groundwork for more aggressive linting in the future, and identifies some additional issues via TODOs.